### PR TITLE
[experimental] Make link and export non-experimental

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -29,7 +29,7 @@ var exportCmd = &cobra.Command{
 }
 
 func init() {
-	addExperimentalCommand(rootCmd, exportCmd)
+	rootCmd.AddCommand(exportCmd)
 
 	exportCmd.Flags().Bool("strict", false, "keep only package source files")
 }

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -39,7 +39,7 @@ var linkCmd = &cobra.Command{
 }
 
 func init() {
-	addExperimentalCommand(rootCmd, linkCmd)
+	rootCmd.AddCommand(linkCmd)
 
 	linkCmd.Flags().Bool("yarn2-link", false, "link yarn packages using yarn2 resolutions")
 	linkCmd.Flags().Bool("go-link", true, "link Go modules")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/typefox/leeway
 go 1.14
 
 require (
-	github.com/GeertJohan/go.rice v1.0.1
+	github.com/GeertJohan/go.rice v1.0.2
 	github.com/creack/pty v1.1.11
 	github.com/daaku/go.zipexe v1.0.1 // indirect
 	github.com/disiqueira/gotree v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/GeertJohan/go.incremental v1.0.0 h1:7AH+pY1XUgQE4Y1HcXYaMqAI0m9yrFqo/
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.1 h1:y8MI9p4J6WKq5b//RP7dr/5eGwzYKyg+15u7YSsDnuc=
 github.com/GeertJohan/go.rice v1.0.1/go.mod h1:af5vUNlDNkCjOZeSGFgIJxDje9qdjsO6hshx0gTmZt4=
+github.com/GeertJohan/go.rice v1.0.2 h1:PtRw+Tg3oa3HYwiDBZyvOJ8LdIyf6lAovJJtr7YOAYk=
+github.com/GeertJohan/go.rice v1.0.2/go.mod h1:af5vUNlDNkCjOZeSGFgIJxDje9qdjsO6hshx0gTmZt4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=


### PR DESCRIPTION
This PR makes link and export no longer experimental. I.e. one can run them without setting `LEEWAY_EXPERIMENTAL`