### PR TITLE
[breaking] Add linting support

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full
+
+USER root
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.33.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,9 @@
 checkoutLocation: leeway
 workspaceLocation: leeway
 
+image:
+  file: .gitpod.Dockerfile
+
 # List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/43_config_ports/
 ports:
 - port: 3000

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.lintTool": "golangci-lint"
+}

--- a/README.md
+++ b/README.md
@@ -132,8 +132,12 @@ config:
   dontTest: false
   # If true disables the enforcement of `go fmt`. By default, if the code is not gofmt'ed the build fails.
   dontCheckGoFmt: false
+  # If true disables the linting stage.
+  dontLint: false
   # A list of flags passed to `go build`. Useful for passing `ldflags`.
   buildFlags: []
+  # Command that's executed to lint the code
+  lintCommand: ["golangci-lint", "run]
 ```
 
 ### Yarn packages

--- a/cmd/bashCompletion.go
+++ b/cmd/bashCompletion.go
@@ -11,8 +11,8 @@ var bashCompletionCmd = &cobra.Command{
 	Use:    "bash-completion",
 	Short:  "Provides bash completion for leeway. Use with `. <(leeway bash-completion)`",
 	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenBashCompletion(os.Stdout)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rootCmd.GenBashCompletion(os.Stdout)
 	},
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -35,14 +35,11 @@ var buildCmd = &cobra.Command{
 			serve, _ = cmd.Flags().GetString("serve")
 		)
 		if watch {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			err := leeway.Build(pkg, opts...)
 			if err != nil {
 				log.Fatal(err)
 			}
-			ctx, cancel = context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(context.Background())
 			if save != "" {
 				saveBuildResult(ctx, save, localCache, pkg)
 			}

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -170,7 +170,6 @@ var collectCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 		}
-		return
 	},
 }
 

--- a/cmd/describe-const.go
+++ b/cmd/describe-const.go
@@ -33,6 +33,7 @@ var describeConstCmd = &cobra.Command{
 		for k, v := range comp.Constants {
 			desc = append(desc, constDesc{Name: k, Value: v})
 		}
+		//nolint:errcheck
 		w.Write(desc)
 	},
 }

--- a/cmd/describe-dependencies.go
+++ b/cmd/describe-dependencies.go
@@ -134,6 +134,7 @@ func serveDepGraph(addr string, pkgs []*leeway.Package) {
 			taddr = fmt.Sprintf("localhost%s", addr)
 		}
 		taddr = fmt.Sprintf("http://%s", taddr)
+		//nolint:errcheck
 		exec.Command(browser, taddr).Start()
 	}()
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/typefox/leeway/pkg/leeway"
 	"github.com/typefox/leeway/pkg/prettyprint"
-	"gopkg.in/yaml.v3"
 )
 
 // describeCmd represents the describe command
@@ -24,7 +23,7 @@ var describeCmd = &cobra.Command{
 			var subcmd *cobra.Command
 			for _, c := range cmd.Commands() {
 				if c.Name() == cmdname {
-					cmd = c
+					subcmd = c
 					break
 				}
 			}
@@ -323,29 +322,10 @@ Packages:
 	}
 }
 
-func describeConfig(cfg leeway.PackageConfig, indent string) string {
-	fc, err := yaml.Marshal(cfg)
-	if err != nil {
-		return fmt.Sprintf("\t!! cannot present: %v !!", err)
-	}
-
-	cfgmap := make(map[string]interface{})
-	err = yaml.Unmarshal(fc, &cfgmap)
-	if err != nil {
-		return fmt.Sprintf("\t!! cannot present: %v !!", err)
-	}
-
-	var res string
-	for k, v := range cfgmap {
-		res += fmt.Sprintf("%s%s:\t%v\n", indent, k, v)
-	}
-	return res
-}
-
 type scriptDescription struct {
 	Name            string                       `json:"name" yaml:"name"`
 	FullName        string                       `json:"fullName" yaml:"fullName"`
-	Description     string                       `json:"description,omitempty" json:"description,omitempty"`
+	Description     string                       `json:"description,omitempty"`
 	FullDescription string                       `json:"fullDescription,omitempty" yaml:"fullDescription,omitempty"`
 	Env             []string                     `json:"env,omitempty" yaml:"env,omitempty"`
 	Dependencies    []packageMetadataDescription `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`

--- a/cmd/experiemental-unmount.go
+++ b/cmd/experiemental-unmount.go
@@ -43,7 +43,7 @@ var unmountCmd = &cobra.Command{
 			return nil
 		}
 
-		filepath.Walk(upper, func(path string, info os.FileInfo, err error) error {
+		err = filepath.Walk(upper, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
@@ -102,6 +102,9 @@ var unmountCmd = &cobra.Command{
 
 			return nil
 		})
+		if err != nil {
+			return err
+		}
 
 		return nil
 	},

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -53,6 +53,7 @@ func formatBuildYaml(fn string, inPlace, fix bool) error {
 	if inPlace {
 		buf := bytes.NewBuffer(nil)
 		out = buf
+		//nolint:errcheck
 		defer func() {
 			f.Seek(0, 0)
 			f.Truncate(0)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -86,7 +86,10 @@ var initCmd = &cobra.Command{
 		}
 		cmp.Content[0].Content = cmps
 
-		f.Seek(0, 0)
+		_, err = f.Seek(0, 0)
+		if err != nil {
+			return err
+		}
 		err = yaml.NewEncoder(f).Encode(&cmp)
 		if err != nil {
 			return err

--- a/cmd/vet.go
+++ b/cmd/vet.go
@@ -22,7 +22,10 @@ var vetCmd = &cobra.Command{
 {{ .Name }}{{"\t"}}{{ .Description }}
 {{ end }}`
 			}
-			w.Write(vet.Checks())
+			err := w.Write(vet.Checks())
+			if err != nil {
+				return err
+			}
 		}
 
 		ws, err := getWorkspace()

--- a/pkg/graphview/graphview.go
+++ b/pkg/graphview/graphview.go
@@ -51,6 +51,7 @@ func serveDepGraphJSON(pkgs []*leeway.Package) http.HandlerFunc {
 
 	js, _ := json.Marshal(graph{Nodes: nodes, Links: links})
 	return func(w http.ResponseWriter, r *http.Request) {
+		//nolint:errcheck
 		w.Write(js)
 	}
 }

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -38,13 +38,6 @@ const (
 	PackageBuilt PackageBuildStatus = "built"
 )
 
-type packageDuringBuild struct {
-	P         *Package
-	Status    PackageBuildStatus
-	Locked    bool
-	FromCache bool
-}
-
 type buildContext struct {
 	buildOptions
 	buildDir string
@@ -164,7 +157,7 @@ func (c *buildContext) LimitConcurrentBuilds() {
 		return
 	}
 
-	c.buildLimit.Acquire(context.Background(), 1)
+	_ = c.buildLimit.Acquire(context.Background(), 1)
 }
 
 // ReleaseConcurrentBuild releases a previously acquired concurrent build limiting token

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -406,7 +406,9 @@ type GoPkgConfig struct {
 	Generate       bool        `yaml:"generate,omitempty"`
 	DontTest       bool        `yaml:"dontTest,omitempty"`
 	DontCheckGoFmt bool        `yaml:"dontCheckGoFmt,omitempty"`
+	DontLint       bool        `yaml:"dontLint,omitempty"`
 	BuildFlags     []string    `yaml:"buildFlags,omitempty"`
+	LintCommand    []string    `yaml:"lintCommand,omitempty"`
 }
 
 // Validate ensures this config can be acted upon/is valid

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -142,12 +142,13 @@ func (r *ConsoleReporter) PackageBuildStarted(pkg *Package) {
 	r.times[pkg.FullName()] = time.Now()
 	r.mu.Unlock()
 
-	io.WriteString(out, color.Sprintf("<fg=yellow>build started</> <gray>(version %s)</>\n", version))
+	_, _ = io.WriteString(out, color.Sprintf("<fg=yellow>build started</> <gray>(version %s)</>\n", version))
 }
 
 // PackageBuildLog is called during a package build whenever a build command produced some output.
 func (r *ConsoleReporter) PackageBuildLog(pkg *Package, isErr bool, buf []byte) {
 	out := r.getWriter(pkg)
+	//nolint:errcheck
 	out.Write(buf)
 }
 
@@ -166,6 +167,7 @@ func (r *ConsoleReporter) PackageBuildFinished(pkg *Package, err error) {
 	if err != nil {
 		msg = color.Sprintf("<red>package build failed</>\n<white>Reason:</> %s\n", err)
 	}
+	//nolint:errcheck
 	io.WriteString(out, msg)
 }
 

--- a/pkg/leeway/scripts.go
+++ b/pkg/leeway/scripts.go
@@ -89,6 +89,9 @@ func (p *Script) Run(opts ...BuildOption) error {
 		return err
 	}
 	buildCtx, err := newBuildContext(options)
+	if err != nil {
+		return err
+	}
 
 	unresolvedArgs, err := findUnresolvedArgumentsInScript(p)
 	if err != nil {
@@ -233,7 +236,7 @@ func executeBashScript(script string, wd string, env []string) error {
 	if err != nil {
 		return err
 	}
-	f.WriteString(script)
+	_, err = f.WriteString(script)
 	if err != nil {
 		return err
 	}

--- a/pkg/leeway/watcher.go
+++ b/pkg/leeway/watcher.go
@@ -36,6 +36,7 @@ func WatchSources(ctx context.Context, pkgs []*Package) (changed <-chan string, 
 	}
 	for f, pkg := range folders {
 		log.WithField("path", f).Debug("adding watcher")
+		//nolint:errcheck
 		watcher.Add(f)
 
 		matcher = append(matcher, &pathMatcher{
@@ -71,6 +72,7 @@ func WatchSources(ctx context.Context, pkgs []*Package) (changed <-chan string, 
 						Base:     dfn,
 						Patterns: patterns,
 					})
+					//nolint:errcheck
 					watcher.Add(dfn)
 					log.WithField("path", dfn).Debug("added new source folder")
 				}

--- a/pkg/linker/golang.go
+++ b/pkg/linker/golang.go
@@ -76,12 +76,18 @@ func linkGoModule(dst *leeway.Package, mods []goModule) error {
 			return err
 		}
 
-		addReplace(gomod, module.Version{Path: mod.Name}, module.Version{Path: relpath}, true, mod.OriginPackage)
+		err = addReplace(gomod, module.Version{Path: mod.Name}, module.Version{Path: relpath}, true, mod.OriginPackage)
+		if err != nil {
+			return err
+		}
 		log.WithField("dst", dst.FullName()).WithField("dep", mod.Name).Debug("linked Go modules")
 	}
 	for _, mod := range mods {
 		for _, r := range mod.Replacements {
-			addReplace(gomod, r.Old, r.New, false, mod.OriginPackage)
+			err = addReplace(gomod, r.Old, r.New, false, mod.OriginPackage)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/vet/docker.go
+++ b/pkg/vet/docker.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 var (
-	filesystemSafePathPattern = regexp.MustCompile("([a-zA-Z0-9\\.]+\\-)+\\-([a-zA-Z0-9\\.\\-]+)")
+	filesystemSafePathPattern = regexp.MustCompile(`([a-zA-Z0-9\.]+\-)+\-([a-zA-Z0-9\.\-]+)`)
 )
 
 func checkDockerCopyFromPackage(pkg *leeway.Package) ([]Finding, error) {


### PR DESCRIPTION
This PR adds a linting stage to Go package builds. Beware: once this PR is merged, we'll try and lint all future Go builds.
By default we use golangci-lint, but this can be configured on a per-package level.

fixes #40 