### PR TITLE
[workspace] Introduce a default variant

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -218,8 +218,10 @@ func newConfigDescription(tpe leeway.PackageType, c leeway.PackageConfig) config
 		cfg["buildFlags"] = c.BuildFlags
 		cfg["dontCheckGoFmt"] = c.DontCheckGoFmt
 		cfg["dontTest"] = c.DontTest
+		cfg["dontLint"] = c.DontLint
 		cfg["generate"] = c.Generate
 		cfg["packaging"] = c.Packaging
+		cfg["lintCommand"] = c.LintCommand
 	case leeway.YarnPackage:
 		c := c.(leeway.YarnPkgConfig)
 		cfg["dontTest"] = c.DontTest

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -884,13 +884,6 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (err error)
 	if cfg.Generate {
 		commands = append(commands, []string{"go", "generate", "-v", "./..."})
 	}
-	if !cfg.DontTest && !buildctx.DontTest {
-		commands = append(commands, [][]string{
-			// we build the test binaries in addition to running the tests regularly, so that downstream packages can run the tests in different environments
-			{"sh", "-c", "mkdir _tests; for i in $(go list ./...); do go test -c $i; [ -e $(basename $i).test ] && mv $(basename $i).test _tests; true; done"},
-			{"go", "test", "-v", "./..."},
-		}...)
-	}
 	if !cfg.DontCheckGoFmt {
 		commands = append(commands, []string{"sh", "-c", `if [ ! $(go fmt ./... | wc -l) -eq 0 ]; then echo; echo; echo please gofmt your code; echo; echo; exit 1; fi`})
 	}
@@ -900,6 +893,13 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (err error)
 		} else {
 			commands = append(commands, cfg.LintCommand)
 		}
+	}
+	if !cfg.DontTest && !buildctx.DontTest {
+		commands = append(commands, [][]string{
+			// we build the test binaries in addition to running the tests regularly, so that downstream packages can run the tests in different environments
+			{"sh", "-c", "mkdir _tests; for i in $(go list ./...); do go test -c $i; [ -e $(basename $i).test ] && mv $(basename $i).test _tests; true; done"},
+			{"go", "test", "-v", "./..."},
+		}...)
 	}
 	if cfg.Packaging == GoApp {
 		cmd := []string{"go", "build"}

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -534,6 +534,11 @@ func (v *PackageVariant) UnmarshalYAML(unmarshal func(interface{}) error) error 
 			return err
 		}
 		cfg, err := unmarshalTypeDependentConfig(k, func(dst interface{}) error {
+			lines := strings.Split(string(b), "\n")
+			for i, l := range lines {
+				lines[i] = "    " + l
+			}
+			b := []byte("config:\n" + strings.Join(lines, "\n"))
 			return yaml.Unmarshal(b, dst)
 		})
 		if err != nil {

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -32,6 +32,7 @@ import (
 type Workspace struct {
 	DefaultTarget       string              `yaml:"defaultTarget,omitempty"`
 	ArgumentDefaults    map[string]string   `yaml:"defaultArgs,omitempty"`
+	DefaultVariant      *PackageVariant     `yaml:"defaultVariant,omitempty"`
 	Variants            []*PackageVariant   `yaml:"variants,omitempty"`
 	EnvironmentManifest EnvironmentManifest `yaml:"environmentManifest,omitempty"`
 
@@ -270,6 +271,9 @@ func loadWorkspace(ctx context.Context, path string, args Arguments, variant str
 				break
 			}
 		}
+	} else if workspace.DefaultVariant != nil {
+		workspace.SelectedVariant = workspace.DefaultVariant
+		log.WithField("defaults", *workspace.SelectedVariant).Debug("applying default variant")
 	}
 
 	var ignores []string


### PR DESCRIPTION
to allow workspace-wide modification of package configurations.

For example:
```YAML
defaultVariant:
  config:
    go:
      lintCommand: 
        - "golangci-lint"
        - "run"
        - "--disable"
        - "govet,typecheck"
```