### PR TITLE
[build] Execute go generate before go get tries to build the package

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -891,10 +891,10 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (err error)
 		}
 	}
 	commands = append(commands, p.PreparationCommands...)
-	commands = append(commands, []string{goCommand, "get", "-v", "./..."})
 	if cfg.Generate {
 		commands = append(commands, []string{goCommand, "generate", "-v", "./..."})
 	}
+	commands = append(commands, []string{goCommand, "get", "-v", "./..."})
 	if !cfg.DontCheckGoFmt {
 		commands = append(commands, []string{"sh", "-c", `if [ ! $(go fmt ./... | wc -l) -eq 0 ]; then echo; echo; echo please gofmt your code; echo; echo; exit 1; fi`})
 	}


### PR DESCRIPTION
When a `go generate` instruction is provided if the generation command create go code there's very high a chance that this code will be missing if `go get` relies on it and thus the build will fail.

This PR moves the generate command to be always done before the get command.

Signed-off-by: Lorenzo Fontana <lo@linux.com>