### PR TITLE
extends --dont-test to also cover "generic" packages

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -213,6 +213,7 @@ func newConfigDescription(tpe leeway.PackageType, c leeway.PackageConfig) config
 	case leeway.GenericPackage:
 		c := c.(leeway.GenericPkgConfig)
 		cfg["commands"] = c.Commands
+		cfg["test"] = c.Test
 	case leeway.GoPackage:
 		c := c.(leeway.GoPkgConfig)
 		cfg["buildFlags"] = c.BuildFlags

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -214,6 +214,7 @@ func newConfigDescription(tpe leeway.PackageType, c leeway.PackageConfig) config
 		c := c.(leeway.GenericPkgConfig)
 		cfg["commands"] = c.Commands
 		cfg["test"] = c.Test
+		cfg["dontTest"] = c.DontTest
 	case leeway.GoPackage:
 		c := c.(leeway.GoPkgConfig)
 		cfg["buildFlags"] = c.BuildFlags

--- a/fixtures/pkgs/generic/BUILD.yaml
+++ b/fixtures/pkgs/generic/BUILD.yaml
@@ -6,3 +6,5 @@ packages:
     config:
       commands:
         - ["echo"]
+      test:
+        - ["echo", "testing"]

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1043,7 +1043,7 @@ func (p *Package) buildGeneric(buildctx *buildContext, wd, result string) (err e
 
 	commands = append(commands, p.PreparationCommands...)
 	commands = append(commands, cfg.Commands...)
-	if !buildctx.DontTest {
+	if !cfg.DontTest && !buildctx.DontTest {
 		commands = append(commands, cfg.Test...)
 	}
 	commands = append(commands, []string{"tar", "cfz", result, "."})

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1022,8 +1022,8 @@ func (p *Package) buildGeneric(buildctx *buildContext, wd, result string) (err e
 	}
 
 	// shortcut: no command == empty package
-	if len(cfg.Commands) == 0 {
-		log.WithField("package", p.FullName()).Debug("package has no commands - creating empty tar")
+	if len(cfg.Commands) == 0 && len(cfg.Test) == 0 {
+		log.WithField("package", p.FullName()).Debug("package has no commands nor test - creating empty tar")
 		return run(buildctx.Reporter, p, nil, wd, "tar", "cfz", result, "--files-from", "/dev/null")
 	}
 
@@ -1043,6 +1043,9 @@ func (p *Package) buildGeneric(buildctx *buildContext, wd, result string) (err e
 
 	commands = append(commands, p.PreparationCommands...)
 	commands = append(commands, cfg.Commands...)
+	if !buildctx.DontTest {
+		commands = append(commands, cfg.Test...)
+	}
 	commands = append(commands, []string{"tar", "cfz", result, "."})
 
 	return executeCommandsForPackage(buildctx, p, wd, commands)

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -466,6 +466,7 @@ func (cfg DockerPkgConfig) AdditionalSources() []string {
 type GenericPkgConfig struct {
 	Commands [][]string `yaml:"commands"`
 	Test     [][]string `yaml:"test,omitempty"`
+	DontTest bool       `yaml:"dontTest,omitempty"`
 }
 
 // AdditionalSources returns a list of unresolved sources coming in through this configuration

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -465,6 +465,7 @@ func (cfg DockerPkgConfig) AdditionalSources() []string {
 // GenericPkgConfig configures a generic package
 type GenericPkgConfig struct {
 	Commands [][]string `yaml:"commands"`
+	Test     [][]string `yaml:"test,omitempty"`
 }
 
 // AdditionalSources returns a list of unresolved sources coming in through this configuration

--- a/pkg/vet/generic.go
+++ b/pkg/vet/generic.go
@@ -19,34 +19,43 @@ func checkArgsReferingToPackage(pkg *leeway.Package) ([]Finding, error) {
 		return nil, fmt.Errorf("Generic package does not have generic package config")
 	}
 
+	checkForFindings := func(findings []Finding, segmentIndex int, seg string) {
+		if !filesystemSafePathPattern.MatchString(seg) {
+			return
+		}
+
+		pth := filesystemSafePathPattern.FindString(seg)
+		log.WithField("pth", pth).WithField("pkg", pkg.FullName()).Debug("found potential package use")
+
+		// we've found something that looks like a path - check if we have a dependency that could satisfy it
+		var satisfied bool
+		for _, dep := range pkg.GetDependencies() {
+			if pkg.BuildLayoutLocation(dep) == pth {
+				satisfied = true
+				break
+			}
+		}
+		if satisfied {
+			return
+		}
+
+		findings = append(findings, Finding{
+			Description: fmt.Sprintf("Command %d refers to %s which looks like a package path, but no dependency satisfies it", segmentIndex, seg),
+			Component:   pkg.C,
+			Package:     pkg,
+			Error:       false,
+		})
+	}
+
 	var findings []Finding
 	for i, cmd := range cfg.Commands {
 		for _, seg := range cmd {
-			if !filesystemSafePathPattern.MatchString(seg) {
-				continue
-			}
-
-			pth := filesystemSafePathPattern.FindString(seg)
-			log.WithField("pth", pth).WithField("pkg", pkg.FullName()).Debug("found potential package use")
-
-			// we've found something that looks like a path - check if we have a dependency that could satisfy it
-			var satisfied bool
-			for _, dep := range pkg.GetDependencies() {
-				if pkg.BuildLayoutLocation(dep) == pth {
-					satisfied = true
-					break
-				}
-			}
-			if satisfied {
-				continue
-			}
-
-			findings = append(findings, Finding{
-				Description: fmt.Sprintf("Command %d refers to %s which looks like a package path, but no dependency satisfies it", i, seg),
-				Component:   pkg.C,
-				Package:     pkg,
-				Error:       false,
-			})
+			checkForFindings(findings, i, seg)
+		}
+	}
+	for i, cmd := range cfg.Test {
+		for _, seg := range cmd {
+			checkForFindings(findings, i, seg)
 		}
 	}
 


### PR DESCRIPTION
Basis for discussion in #53 

This PR adds two things, actually:
 - the `Test` field to generic packages, which has the same type as `Command`: `[][]string`
 - the `DontTest` field, analogous to the other package types. This is not strictly required, but make sense as it allows to (temporarily) disable a package at dev time analogous to the other package types without commenting out the `test` section in the build.yaml.