### PR TITLE
[docker] Support metadata in Docker packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ config:
 config:
   # Dockerfile is the name of the Dockerfile to build. Automatically added to the package sources.
   dockerfile: "Dockerfile"
+  # Metadata produces a metadata.yaml file in the resulting package tarball.
+  metadata:
+    foo: bar
   # build args are Docker build arguments. Often we just pass leeway build arguments along here.
   buildArgs:
   - arg=value

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -456,6 +456,7 @@ type DockerPkgConfig struct {
 	Image      []string          `yaml:"image,omitempty"`
 	BuildArgs  map[string]string `yaml:"buildArgs,omitempty"`
 	Squash     bool              `yaml:"squash,omitempty"`
+	Metadata   map[string]string `yaml:"metadata,omitempty"`
 }
 
 // AdditionalSources returns a list of unresolved sources coming in through this configuration


### PR DESCRIPTION
Adds a new field to Docker package configuration which gets serialised back to YAML and becomes part of the package tarball in `metadata.yaml`. This provides a convenient way to attach metadata to Docker builds.