### PR TITLE
[docker] Support Docker CLI arguments during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ config:
   image:
   - gitpod/leeway:latest
   - gitpod/leeway:${__pkg_version}
+  # cliArgs adds arguments to the Docker CLI build call
+  cliArgs:
+  - "--network=host"
 ```
 
 ### Generic packages

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1019,6 +1019,7 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (err er
 	if cfg.Squash {
 		buildcmd = append(buildcmd, "--squash")
 	}
+	buildcmd = append(buildcmd, cfg.CLIArgs...)
 	buildcmd = append(buildcmd, ".")
 	commands = append(commands, buildcmd)
 

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -462,6 +462,7 @@ type DockerPkgConfig struct {
 	Image      []string          `yaml:"image,omitempty"`
 	BuildArgs  map[string]string `yaml:"buildArgs,omitempty"`
 	Squash     bool              `yaml:"squash,omitempty"`
+	CLIArgs    []string          `yaml:"cliArgs,omitempty"`
 	Metadata   map[string]string `yaml:"metadata,omitempty"`
 }
 


### PR DESCRIPTION
## Description
Adds `dockerArgs` to Docker package config which appends arguments to a docker build
