### PR TITLE
add "docker-build-options" for passing options to "docker build"

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -171,6 +171,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("dont-retag", false, "Disable Docker image re-tagging (defaults to false)")
 	cmd.Flags().UintP("max-concurrent-tasks", "j", uint(runtime.NumCPU()), "Limit the number of max concurrent build tasks - set to 0 to disable the limit")
 	cmd.Flags().String("coverage-output-path", "", "Output path where test coverage file will be copied after running tests")
+	cmd.Flags().StringToString("docker-build-options", nil, "Options passed to all 'docker build' commands")
 }
 
 func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemCache) {
@@ -275,6 +276,12 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		_ = os.MkdirAll(coverageOutputPath, 0644)
 	}
 
+	var dockerBuildOptions leeway.DockerBuildOptions
+	dockerBuildOptions, err = cmd.Flags().GetStringToString("docker-build-options")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return []leeway.BuildOption{
 		leeway.WithLocalCache(localCache),
 		leeway.WithRemoteCache(remoteCache),
@@ -286,6 +293,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		leeway.WithMaxConcurrentTasks(int64(maxConcurrentTasks)),
 		leeway.WithCoverageOutputPath(coverageOutputPath),
 		leeway.WithDontRetag(dontRetag),
+		leeway.WithDockerBuildOptions(&dockerBuildOptions),
 	}, localCache
 }
 

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -213,9 +213,13 @@ type buildOptions struct {
 	MaxConcurrentTasks     int64
 	CoverageOutputPath     string
 	DontRetag              bool
+	DockerBuildOptions     *DockerBuildOptions
 
 	context *buildContext
 }
+
+// DockerBuildOptions are options passed to "docker build"
+type DockerBuildOptions map[string]string
 
 // BuildOption configures the build behaviour
 type BuildOption func(*buildOptions) error
@@ -300,6 +304,14 @@ func WithCoverageOutputPath(output string) BuildOption {
 func WithDontRetag(dontRetag bool) BuildOption {
 	return func(opts *buildOptions) error {
 		opts.DontRetag = dontRetag
+		return nil
+	}
+}
+
+// WithDockerBuildOptions are passed to "docker build"
+func WithDockerBuildOptions(dockerBuildOpts *DockerBuildOptions) BuildOption {
+	return func(opts *buildOptions) error {
+		opts.DockerBuildOptions = dockerBuildOpts
 		return nil
 	}
 }
@@ -1018,6 +1030,11 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (err er
 	}
 	if cfg.Squash {
 		buildcmd = append(buildcmd, "--squash")
+	}
+	if buildctx.DockerBuildOptions != nil {
+		for opt, v := range *buildctx.DockerBuildOptions {
+			buildcmd = append(buildcmd, fmt.Sprintf("--%s=%s", opt, v))
+		}
 	}
 	buildcmd = append(buildcmd, ".")
 	commands = append(commands, buildcmd)


### PR DESCRIPTION
## Description
allows `leeway --docker-build-options=bridge=none`, for example.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
