### PR TITLE
fix golang build error

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -932,7 +932,7 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (err error)
 	if cfg.Generate {
 		commands = append(commands, []string{goCommand, "generate", "-v", "./..."})
 	}
-	commands = append(commands, []string{goCommand, "mod", "download", "-v", "./..."})
+	commands = append(commands, []string{goCommand, "mod", "download", "-x"})
 
 	if !cfg.DontCheckGoFmt {
 		commands = append(commands, []string{"sh", "-c", `if [ ! $(go fmt ./... | wc -l) -eq 0 ]; then echo; echo; echo please gofmt your code; echo; echo; exit 1; fi`})


### PR DESCRIPTION
## Description
go mod download not support "-v" and "./...", use "-v" instead

## Related Issue(s)

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

