### PR TITLE
Improve provenance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ cat provenance-bundle.jsonl | jq -r .payload | base64 -d | jq
 ## Caveats
 - provenance is part of the leeway package version, i.e. when you enable provenance that will naturally invalidate previously built packages.
 - provenance is not supported for nested workspaces. The presence of `LEEWAY_NESTED_WORKSPACE` will make the build fail.
+- if attestation bundle entries grow too large this can break the build process. Use `LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE` to set the buffer size in bytes. This defaults to 2MiB. The larger this buffer is, the larger bundle entries can be used, but the more memory the build process will consume. If you exceed the default, inspect the bundles first (especially the one that fails to load) and see if the produced `subjects` make sense.
 
 # Debugging
 When a build fails, or to get an idea of how leeway assembles dependencies, run your build with `leeway build -c local` (local cache only) and inspect your `$LEEWAY_BUILD_DIR`.

--- a/README.md
+++ b/README.md
@@ -301,13 +301,19 @@ To support SLSA level 2, leeway can sign the attestations it produces. To this e
 You can inspect the generated attestation bundle by extracting it from the built and cached archive. For example:
 ```bash
 # run a build
-leeway build --save /tmp/build.tar.gz
+leeway build //:app
 
-# extract bundle
-tar xf /tmp/build.tar.gz ./provenance-bundle.jsonl
+# export the attestation bundle
+leeway provenance export //:app
 
-# inspect the bundle
-cat provenance-bundle.jsonl | jq -r .payload | base64 -d | jq
+# export the decoded attestation bundle
+leeway provenance export --decode //:app
+
+# verify that all material came from a Git repo
+leeway provenance assert --git-only //:app
+
+# verify that all subjects were built using leeway
+leeway provenance asert --built-with-leeway //:app
 ```
 
 ## Caveats

--- a/cmd/describe-gitinfo.go
+++ b/cmd/describe-gitinfo.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"github.com/gitpod-io/leeway/pkg/leeway"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// describeGitInfoCmd represents the describeTree command
+var describeGitInfoCmd = &cobra.Command{
+	Use:   "git-info",
+	Short: "Prints the Git info consumed by leeway",
+	Run: func(cmd *cobra.Command, args []string) {
+		comp, pkg, script, _ := getTarget(args, false)
+
+		var (
+			nfo *leeway.GitInfo
+			loc string
+		)
+		if comp != nil {
+			nfo = comp.Git()
+			loc = comp.Origin
+		} else if pkg != nil {
+			nfo = pkg.C.Git()
+			loc = pkg.C.Origin
+		} else if script != nil {
+			nfo = script.C.Git()
+			loc = script.C.Origin
+		} else {
+			log.Fatal("no target given - try passing a package or component")
+		}
+
+		if nfo == nil {
+			log.WithField("loc", loc).Fatal("not a Git working copy")
+		}
+		w := getWriterFromFlags(cmd)
+		if w.FormatString == "" {
+			w.FormatString = `dirty:	{{.Dirty }}
+origin:	{{ .Origin }}
+commit:	{{ .Commit }}
+`
+		}
+		err := w.Write(nfo)
+		if err != nil {
+			log.WithError(err).Fatal("cannot write git info")
+		}
+	},
+}
+
+func init() {
+	describeCmd.AddCommand(describeGitInfoCmd)
+	addFormatFlags(describeGitInfoCmd)
+}

--- a/cmd/provenance-assert.go
+++ b/cmd/provenance-assert.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/gitpod-io/leeway/pkg/provutil"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/bom/pkg/provenance"
+)
+
+// provenanceExportCmd represents the provenance assert command
+var provenanceAssertCmd = &cobra.Command{
+	Use:   "assert <package>",
+	Short: "Makes assertions about the provenance of a package",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		_, pkg, _, _ := getTarget(args, false)
+		if pkg == nil {
+			log.Fatal("provenance export requires a package")
+		}
+
+		_, cache := getBuildOpts(cmd)
+		pkgFN, ok := cache.Location(pkg)
+		if !ok {
+			log.Fatalf("%s is not built", pkg.FullName())
+		}
+
+		var assertions provutil.Assertions
+		if signed, _ := cmd.Flags().GetBool("signed"); signed {
+			var key in_toto.Key
+			err := key.LoadKeyDefaults(pkg.C.W.Provenance.KeyPath)
+			if err != nil {
+				log.WithError(err).Fatal("cannot load key from " + pkg.C.W.Provenance.KeyPath)
+			}
+			assertions = append(assertions, provutil.AssertSignedWith(key))
+		}
+		if do, _ := cmd.Flags().GetBool("leeway-built"); do {
+			assertions = append(assertions, provutil.AssertBuiltWithLeeway)
+		}
+		if ver, _ := cmd.Flags().GetString("leeway-version"); ver != "" {
+			assertions = append(assertions, provutil.AssertBuiltWithLeewayVersion(ver))
+		}
+		if do, _ := cmd.Flags().GetBool("git-only"); do {
+			assertions = append(assertions, provutil.AssertGitMaterialOnly)
+		}
+
+		var failures []provutil.Violation
+		stmt := provenance.NewSLSAStatement()
+		err := provutil.AccessPkgAttestationBundle(pkgFN, func(env *provenance.Envelope) error {
+			if env.PayloadType != in_toto.PayloadType {
+				log.Warnf("only supporting %s payloads, not %s - skipping", in_toto.PayloadType, env.PayloadType)
+				return nil
+			}
+
+			failures = append(assertions.AssertEnvelope(env), failures...)
+
+			raw, err := base64.StdEncoding.DecodeString(env.Payload)
+			if err != nil {
+				return err
+			}
+			err = json.Unmarshal(raw, &stmt)
+			if err != nil {
+				return err
+			}
+
+			failures = append(assertions.AssertStatement(stmt), failures...)
+
+			return nil
+		})
+		if err != nil {
+			log.WithError(err).Fatal("cannot assert attestation bundle")
+		}
+
+		if len(failures) != 0 {
+			for _, f := range failures {
+				log.Error(f.String())
+			}
+			log.Fatal("failed")
+		}
+	},
+}
+
+func init() {
+	provenanceAssertCmd.Flags().Bool("signed", false, "ensure that all entries in the attestation bundle are signed and valid under the given key")
+	provenanceAssertCmd.Flags().Bool("built-with-leeway", false, "ensure that all entries in the attestation bundle are built by leeway")
+	provenanceAssertCmd.Flags().String("built-with-leeway-version", "", "ensure that all entries in the attestation bundle are built by a specific leeway version")
+	provenanceAssertCmd.Flags().Bool("git-only", false, "ensure that all entries in the attestation bundle are built directly from Git (i.e. only have git material entries)")
+
+	addBuildFlags(provenanceAssertCmd)
+	provenanceCmd.AddCommand(provenanceAssertCmd)
+}

--- a/cmd/provenance-export.go
+++ b/cmd/provenance-export.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+
+	"github.com/gitpod-io/leeway/pkg/provutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/bom/pkg/provenance"
+)
+
+// provenanceExportCmd represents the provenance export command
+var provenanceExportCmd = &cobra.Command{
+	Use:   "export <package>",
+	Short: "Exports the provenance bundle of a (previously built) package",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		_, pkg, _, _ := getTarget(args, false)
+		if pkg == nil {
+			log.Fatal("provenance export requires a package")
+		}
+
+		_, cache := getBuildOpts(cmd)
+		pkgFN, ok := cache.Location(pkg)
+		if !ok {
+			log.Fatalf("%s is not built", pkg.FullName())
+		}
+
+		decode, _ := cmd.Flags().GetBool("decode")
+		out := json.NewEncoder(os.Stdout)
+		err := provutil.AccessPkgAttestationBundle(pkgFN, func(env *provenance.Envelope) error {
+			if !decode {
+				return out.Encode(env)
+			}
+
+			dec, err := base64.StdEncoding.DecodeString(env.Payload)
+			if err != nil {
+				return err
+			}
+
+			// we make a Marshal(Unmarshal(...)) detour here to ensure we're still outputing
+			// newline delimited JSON. We have no idea how the payload actually looks like, just
+			// that it's valid JSON.
+			var decc map[string]interface{}
+			err = json.Unmarshal(dec, &decc)
+			if err != nil {
+				return err
+			}
+			err = out.Encode(decc)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+		if err != nil {
+			log.WithError(err).Fatal("cannot extract attestation bundle")
+		}
+	},
+}
+
+func init() {
+	provenanceExportCmd.Flags().Bool("decode", false, "decode the base64 payload of the envelopes")
+
+	provenanceCmd.AddCommand(provenanceExportCmd)
+	addBuildFlags(provenanceExportCmd)
+}

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// provenanceCmd represents the provenance command
+var provenanceCmd = &cobra.Command{
+	Use:   "provenance <command>",
+	Short: "Helpful commands for inspecing package provenance",
+	Args:  cobra.MinimumNArgs(1),
+}
+
+func init() {
+	rootCmd.AddCommand(provenanceCmd)
+}

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -976,8 +976,9 @@ func (p *Package) buildYarn(buildctx *buildContext, wd, result string) (bld *pac
 	}
 	res.PackageCommands = pkgCommands
 	res.PostBuild = func() (fileset, string, error) {
+		ignoreNodeModules := func(fn string) bool { return strings.Contains(fn, "node_modules/") }
 		fn := filepath.Join(wd, resultDir)
-		fset, err := computeFileset(fn)
+		fset, err := computeFileset(fn, ignoreNodeModules)
 		return fset, fn, err
 	}
 

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -933,10 +933,6 @@ func (p *Package) buildYarn(buildctx *buildContext, wd, result string) (bld *pac
 			}
 		}
 
-		if p.C.W.Provenance.Enabled {
-			pkgCommands = append(pkgCommands, []string{"cp", provenanceBundleFilename, "_mirror"})
-		}
-
 		dst := filepath.Join("_mirror", fmt.Sprintf("%s.tar.gz", p.FilesystemSafeName()))
 		pkgCommands = append(pkgCommands, [][]string{
 			{"sh", "-c", fmt.Sprintf("yarn generate-lock-entry --resolved file://./%s > _mirror/content_yarn.lock", dst)},

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -872,7 +872,7 @@ func (p *Package) WriteVersionManifest(out io.Writer) error {
 
 	bundle = append(bundle, fmt.Sprintf("buildProcessVersion: %d\n", buildProcessVersions[p.Type]))
 	if p.C.W.Provenance.Enabled {
-		bundle = append(bundle, "provenance")
+		bundle = append(bundle, fmt.Sprintf("provenance: version=%d", provenanceProcessVersion))
 		if p.C.W.Provenance.SLSA {
 			bundle = append(bundle, " slsa")
 		}

--- a/pkg/leeway/provenance.go
+++ b/pkg/leeway/provenance.go
@@ -75,7 +75,8 @@ func writeProvenance(p *Package, buildctx *buildContext, builddir string, subjec
 		bundle[string(entry)] = struct{}{}
 	}
 
-	f, err := os.OpenFile(filepath.Join(builddir, provenanceBundleFilename), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	fn := filepath.Join(builddir, provenanceBundleFilename)
+	f, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("cannot write provenance for %s: %w", p.FullName(), err)
 	}
@@ -87,6 +88,8 @@ func writeProvenance(p *Package, buildctx *buildContext, builddir string, subjec
 			return fmt.Errorf("cannot write provenance for %s: %w", p.FullName(), err)
 		}
 	}
+	log.WithField("fn", fn).WithField("package", p.FullName()).Debug("wrote provenance bundle")
+
 	return nil
 }
 

--- a/pkg/leeway/provenance.go
+++ b/pkg/leeway/provenance.go
@@ -322,7 +322,7 @@ func sha256Hash(fn string) (res string, err error) {
 
 type fileset map[string]struct{}
 
-func computeFileset(dir string) (fileset, error) {
+func computeFileset(dir string, ignoreFN ...func(fn string) bool) (fileset, error) {
 	res := make(fileset)
 	err := filepath.WalkDir(dir, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
@@ -330,6 +330,11 @@ func computeFileset(dir string) (fileset, error) {
 		}
 		if info.IsDir() {
 			return nil
+		}
+		for _, ignore := range ignoreFN {
+			if ignore(path) {
+				return nil
+			}
 		}
 
 		fn := strings.TrimPrefix(path, dir)
@@ -340,7 +345,7 @@ func computeFileset(dir string) (fileset, error) {
 	return res, err
 }
 
-// Sub produces a new fileset with all entries from the other fileset subjectraced
+// Sub produces a new fileset with all entries from the other fileset
 func (fset fileset) Sub(other fileset) fileset {
 	res := make(fileset, len(fset))
 	for fn := range fset {

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -95,6 +96,15 @@ func (mf EnvironmentManifest) Hash() (string, error) {
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// MarshalJSON marshals a built-up environment manifest into JSON
+func (mf EnvironmentManifest) MarshalJSON() ([]byte, error) {
+	res := make(map[string]string, len(mf))
+	for _, e := range mf {
+		res[e.Name] = e.Value
+	}
+	return json.Marshal(res)
 }
 
 // EnvironmentManifestEntry represents an entry in the environment manifest

--- a/pkg/provutil/access.go
+++ b/pkg/provutil/access.go
@@ -1,0 +1,30 @@
+package provutil
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/gitpod-io/leeway/pkg/leeway"
+	"sigs.k8s.io/bom/pkg/provenance"
+)
+
+// AccessPkgAttestationBundle provides access to the attestation bundle entries from a cached build artifact.
+// pkgFN is expected to point to a cached tar file.
+func AccessPkgAttestationBundle(pkgFN string, handler func(env *provenance.Envelope) error) error {
+	return leeway.AccessAttestationBundleInCachedArchive(pkgFN, func(bundle io.Reader) error {
+		var env provenance.Envelope
+		dec := json.NewDecoder(bundle)
+		for dec.More() {
+			err := dec.Decode(&env)
+			if err != nil {
+				return err
+			}
+
+			err = handler(&env)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/provutil/assert.go
+++ b/pkg/provutil/assert.go
@@ -1,0 +1,146 @@
+package provutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gitpod-io/leeway/pkg/leeway"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/bom/pkg/provenance"
+)
+
+type Assertion struct {
+	Name        string
+	Description string
+	Run         func(stmt *provenance.Statement) []Violation
+	RunEnvelope func(env *provenance.Envelope) []Violation
+}
+
+type Violation struct {
+	Assertion *Assertion
+	Statement *provenance.Statement
+	Desc      string
+}
+
+func (v Violation) String() string {
+	if v.Statement == nil {
+		return fmt.Sprintf("failed %s: %s", v.Assertion.Name, v.Desc)
+	}
+
+	return fmt.Sprintf("%s failed %s: %s", v.Statement.Predicate.Recipe.EntryPoint, v.Assertion.Name, v.Desc)
+}
+
+type Assertions []*Assertion
+
+func (a Assertions) AssertEnvelope(env *provenance.Envelope) (failed []Violation) {
+	for _, as := range a {
+		if as.RunEnvelope == nil {
+			continue
+		}
+
+		res := as.RunEnvelope(env)
+		for i := range res {
+			res[i].Assertion = as
+		}
+		failed = append(failed, res...)
+	}
+	return
+}
+
+func (a Assertions) AssertStatement(stmt *provenance.Statement) (failed []Violation) {
+	// we must not keep a reference to stmt around - it will change for each invocation
+	s := *stmt
+	for _, as := range a {
+		if as.Run == nil {
+			continue
+		}
+
+		res := as.Run(stmt)
+		for i := range res {
+			res[i].Statement = &s
+			res[i].Assertion = as
+		}
+		failed = append(failed, res...)
+	}
+	return
+}
+
+var AssertBuiltWithLeeway = &Assertion{
+	Name:        "built-with-leeway",
+	Description: "ensures all bundle entries have been built with leeway",
+	Run: func(stmt *provenance.Statement) []Violation {
+		if strings.HasPrefix(stmt.Predicate.Builder.ID, leeway.ProvenanceBuilderID) {
+			return nil
+		}
+
+		return []Violation{
+			{Desc: "was not built using leeway"},
+		}
+	},
+}
+
+func AssertBuiltWithLeewayVersion(version string) *Assertion {
+	return &Assertion{
+		Name:        "built-with-leeway-version",
+		Description: "ensures all bundle entries which have been built using leeway, used version " + version,
+		Run: func(stmt *provenance.Statement) []Violation {
+			if !strings.HasPrefix(stmt.Predicate.Builder.ID, leeway.ProvenanceBuilderID) {
+				return nil
+			}
+
+			if stmt.Predicate.Builder.ID != leeway.ProvenanceBuilderID+":"+version {
+				return []Violation{{Desc: "was built using leeway version " + strings.TrimPrefix(stmt.Predicate.Builder.ID, leeway.ProvenanceBuilderID+":")}}
+			}
+
+			return nil
+		},
+	}
+}
+
+var AssertGitMaterialOnly = &Assertion{
+	Name:        "git-material-only",
+	Description: "ensures all subjects were built from Git material only",
+	Run: func(stmt *provenance.Statement) []Violation {
+		for _, m := range stmt.Predicate.Materials {
+			if strings.HasPrefix(m.URI, "git+") || strings.HasPrefix(m.URI, "git://") {
+				continue
+			}
+
+			return []Violation{{
+				Desc: "contains non-Git material, e.g. " + m.URI,
+			}}
+		}
+		return nil
+	},
+}
+
+func AssertSignedWith(key in_toto.Key) *Assertion {
+	return &Assertion{
+		Name:        "signed-with",
+		Description: "ensures all envelopes are signed with the given key",
+		RunEnvelope: func(env *provenance.Envelope) []Violation {
+			for _, s := range env.Signatures {
+				raw, err := json.Marshal(s)
+				if err != nil {
+					return []Violation{{Desc: "assertion error: " + err.Error()}}
+				}
+				var sig in_toto.Signature
+				err = json.Unmarshal(raw, &sig)
+				if err != nil {
+					return []Violation{{Desc: "assertion error: " + err.Error()}}
+				}
+
+				err = in_toto.VerifySignature(key, sig, []byte(env.Payload))
+				if err != nil {
+					log.WithError(err).WithField("signature", sig).Debug("signature does not match")
+					continue
+				}
+
+				return nil
+			}
+			return []Violation{{Desc: "not signed with the given key"}}
+		},
+	}
+}


### PR DESCRIPTION
This PR builds on prior work which introduced SLSA provenance support to leeway. It adds 
- some debugging functionality and inspection CLI,
- improves memory efficiency during attestation bundle generation,
- increases the level of detail in the generated provenance
- fixes the Git status dirty flag (add adds `leeway describe git-info`)