### PR TITLE
Fix provenance generation issues with tar-file exported Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ leeway provenance assert --git-only //:app
 
 # verify that all subjects were built using leeway
 leeway provenance asert --built-with-leeway //:app
+
+# decode an attestation bundle from a file (also works for assertions)
+leeway provenance export --decode file://some-bundle.jsonl
 ```
 
 ## Caveats

--- a/cmd/provenance-assert.go
+++ b/cmd/provenance-assert.go
@@ -28,6 +28,8 @@ var provenanceAssertCmd = &cobra.Command{
 
 		var assertions provutil.Assertions
 		if signed, _ := cmd.Flags().GetBool("signed"); signed {
+			log.Warn("checking signatures is most likely broken and will probably return false results")
+
 			var keyPath string
 			if pkg == nil {
 				keyPath = os.Getenv("LEEWAY_PROVENANCE_KEYPATH")

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -6,9 +6,10 @@ import (
 
 // provenanceCmd represents the provenance command
 var provenanceCmd = &cobra.Command{
-	Use:   "provenance <command>",
-	Short: "Helpful commands for inspecing package provenance",
-	Args:  cobra.MinimumNArgs(1),
+	Use:     "provenance <command>",
+	Short:   "Helpful commands for inspecing package provenance",
+	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"prov"},
 }
 
 func init() {

--- a/pkg/leeway/provenance.go
+++ b/pkg/leeway/provenance.go
@@ -295,6 +295,12 @@ type provenanceEnvironment struct {
 func (p *Package) inTotoMaterials() ([]in_toto.ProvenanceMaterial, error) {
 	res := make([]in_toto.ProvenanceMaterial, 0, len(p.Sources))
 	for _, src := range p.Sources {
+		if stat, err := os.Lstat(src); err != nil {
+			return nil, err
+		} else if !stat.Mode().IsRegular() {
+			continue
+		}
+
 		hash, err := sha256Hash(src)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
When building Docker images without pushing them to a registry, leeway will call `docker save` instead. In this case we still need to add the provenance bundle, and compute the subject list from the entries of tar file rather than a fileset.

This PR also enables the `leeway provenance` commands for attestation bundle files in addition to pulling them out of a package.