### PR TITLE
Build and release Darwin ARM64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,13 @@ builds:
   - CGO_ENABLED=0
   ldflags:
   - -s -w -X github.com/gitpod-io/leeway/pkg/leeway.Version={{.Version}}-{{.ShortCommit}}
+  goos:
+    - linux
+    - darwin
+  goarch:
+    - "386"
+    - amd64
+    - arm64
   ignore:
   - goos: darwin
     goarch: 386


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The current leeway doesn't include the Darwin ARM64 release

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
I don't know how to trigger the gorelease to create a new release in my forked repository.
But I think adding this attribute to the gorelease.yml may work.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Support Darwin ARM64.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A