### PR TITLE
Revert "Build and release Darwin ARM64"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,13 +11,6 @@ builds:
   - CGO_ENABLED=0
   ldflags:
   - -s -w -X github.com/gitpod-io/leeway/pkg/leeway.Version={{.Version}}-{{.ShortCommit}}
-  goos:
-    - linux
-    - darwin
-  goarch:
-    - "386"
-    - amd64
-    - arm64
   ignore:
   - goos: darwin
     goarch: 386


### PR DESCRIPTION
Reverts gitpod-io/leeway#84

Unfortunately this doesn't build:
```
      • pipe skipped              error=not available for snapshots
   • building binaries
      • building                  binary=/workspace/leeway/dist/leeway_darwin_amd64/leeway
      • building                  binary=/workspace/leeway/dist/leeway_linux_386/leeway
      • building                  binary=/workspace/leeway/dist/leeway_linux_amd64/leeway
      • building                  binary=/workspace/leeway/dist/leeway_linux_arm64/leeway
   ⨯ build failed after 24.46s error=failed to build for darwin_amd64: # github.com/opencontainers/runc/libcontainer/configs
../go/pkg/mod/github.com/opencontainers/runc@v1.1.1/libcontainer/configs/mount.go:34:11: undefined: unix.MountAttr
../go/pkg/mod/github.com/opencontainers/runc@v1.1.1/libcontainer/configs/mount.go:47:17: undefined: unix.MS_BIND
```