### PR TITLE
Add package instantiation

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -133,10 +133,11 @@ func absPackageName(workspace leeway.Workspace, name string) string {
 }
 
 type packageMetadataDescription struct {
-	Name      string `json:"name" yaml:"name"`
-	FullName  string `json:"fullName" yaml:"fullName"`
-	Version   string `json:"version" yaml:"version"`
-	Emphemral bool   `json:"ephemeral" yaml:"ephemeral"`
+	Name       string `json:"name" yaml:"name"`
+	FullName   string `json:"fullName" yaml:"fullName"`
+	Version    string `json:"version" yaml:"version"`
+	Emphemral  bool   `json:"ephemeral" yaml:"ephemeral"`
+	InstanceOf string `json:"instanceOf" yaml:"instanceOf"`
 }
 
 func newMetadataDescription(pkg *leeway.Package) packageMetadataDescription {
@@ -146,10 +147,11 @@ func newMetadataDescription(pkg *leeway.Package) packageMetadataDescription {
 	}
 
 	return packageMetadataDescription{
-		Name:      pkg.Name,
-		FullName:  pkg.FullName(),
-		Version:   version,
-		Emphemral: pkg.Ephemeral,
+		Name:       pkg.Name,
+		FullName:   pkg.FullName(),
+		Version:    version,
+		Emphemral:  pkg.Ephemeral,
+		InstanceOf: pkg.InstanceOf,
 	}
 }
 
@@ -264,7 +266,7 @@ Version Relevant Arguments:
 {{ if .Dependencies -}}
 Dependencies:
 {{- range $k, $v := .Dependencies }}
-{{"\t"}}{{ $v.FullName -}}{{"\t"}}{{ $v.Version -}}
+{{"\t"}}{{ $v.FullName -}}{{"\t"}}{{ $v.Version -}}{{ if $v.InstanceOf }}{{"\t"}}(instanciated from {{$v.InstanceOf}}){{ end -}}
 {{ end }}
 Layout:
 {{- range $k, $v := .Layout }}

--- a/fixtures/pkgs/instanciated/BUILD.yaml
+++ b/fixtures/pkgs/instanciated/BUILD.yaml
@@ -1,0 +1,17 @@
+packages:
+  - name: variant
+    type: generic
+    config:
+      commands:
+        - ["echo", "${message}"]
+  - name: all
+    type: generic
+    deps:
+      - ref: :variant
+        alias: hello
+        args:
+          message: hello
+      - ref: :variant
+        alias: world
+        args:
+          message: world

--- a/fixtures/pkgs/instanciated/BUILD.yaml
+++ b/fixtures/pkgs/instanciated/BUILD.yaml
@@ -4,6 +4,12 @@ packages:
     config:
       commands:
         - ["echo", "${message}"]
+  - name: rabbit-hole
+    type: generic
+    deps:
+      - ref: :variant
+        args:
+          message: "${passingThrough}"
   - name: all
     type: generic
     deps:
@@ -15,3 +21,6 @@ packages:
         alias: world
         args:
           message: world
+      - ref: :rabbit-hole
+        args:
+          passingThrough: awesome

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -573,7 +573,7 @@ func filterExcludedComponents(variant *PackageVariant, c *Component) (ignoreComp
 
 	for _, p := range c.Packages {
 		for i, dep := range p.Dependencies {
-			segs := strings.Split(dep, ":")
+			segs := strings.Split(dep.Ref, ":")
 			if len(segs) != 2 {
 				continue
 			}
@@ -622,7 +622,7 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 	// replace build args
 	var rfc []byte = fc
 	if len(args) > 0 {
-		rfc = replaceBuildArguments(fc, compargs)
+		rfc = rawReplaceBuildArguments(fc, compargs)
 	}
 
 	var (
@@ -729,11 +729,11 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 
 		// make all dependencies fully qualified
 		for idx, dep := range pkg.Dependencies {
-			if !strings.HasPrefix(dep, ":") {
+			if !strings.HasPrefix(dep.Ref, ":") {
 				continue
 			}
 
-			pkg.Dependencies[idx] = comp.Name + dep
+			pkg.Dependencies[idx].Ref = comp.Name + dep.Ref
 		}
 		// make all layout entries full qualified
 		if pkg.Layout == nil {


### PR DESCRIPTION
## Description
This PR adds "package instantiation" to leeway, i.e. enabling packages to pass arguments to their dependencies.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #93

## How to test
See readme

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Support for package instantiation, i.e. passing arguments to dependencies
```
