### PR TITLE
[breaking] Remove Docker retagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,6 @@ config:
 ```
 
 ### Docker packages
-Docker packages have a default "retagging" behaviour: even when a Docker package is built already, i.e. it's leeway version didn't change,
-leeway will ensure that an image exists with the names specified in the package config. For example, if a Docker package has `leeway/some-package:${version}` specified,
-and `${version}` changes, but otherwise the package has been built before, leeway will "re-tag" the previously built image to be available under `leeway/some-package:${version}`.
-This behaviour can be disabled using `--dont-retag`.
 ```YAML
 config:
   # Dockerfile is the name of the Dockerfile to build. Automatically added to the package sources.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -168,7 +168,6 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().String("dump-plan", "", "Writes the build plan as JSON to a file. Use \"-\" to write the build plan to stderr.")
 	cmd.Flags().Bool("werft", false, "Produce werft CI compatible output")
 	cmd.Flags().Bool("dont-test", false, "Disable all package-level tests (defaults to false)")
-	cmd.Flags().Bool("dont-retag", false, "Disable Docker image re-tagging (defaults to false)")
 	cmd.Flags().Bool("jailed-execution", false, "Run all build commands using runc (defaults to false)")
 	cmd.Flags().UintP("max-concurrent-tasks", "j", uint(runtime.NumCPU()), "Limit the number of max concurrent build tasks - set to 0 to disable the limit")
 	cmd.Flags().String("coverage-output-path", "", "Output path where test coverage file will be copied after running tests")
@@ -263,11 +262,6 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		log.Fatal(err)
 	}
 
-	dontRetag, err := cmd.Flags().GetBool("dont-retag")
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	maxConcurrentTasks, err := cmd.Flags().GetUint("max-concurrent-tasks")
 	if err != nil {
 		log.Fatal(err)
@@ -299,7 +293,6 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		leeway.WithDontTest(dontTest),
 		leeway.WithMaxConcurrentTasks(int64(maxConcurrentTasks)),
 		leeway.WithCoverageOutputPath(coverageOutputPath),
-		leeway.WithDontRetag(dontRetag),
 		leeway.WithDockerBuildOptions(&dockerBuildOptions),
 		leeway.WithJailedExecution(jailedExecution),
 	}, localCache

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -246,7 +246,6 @@ type buildOptions struct {
 	DontTest               bool
 	MaxConcurrentTasks     int64
 	CoverageOutputPath     string
-	DontRetag              bool
 	DockerBuildOptions     *DockerBuildOptions
 	JailedExecution        bool
 
@@ -331,14 +330,6 @@ func WithMaxConcurrentTasks(n int64) BuildOption {
 func WithCoverageOutputPath(output string) BuildOption {
 	return func(opts *buildOptions) error {
 		opts.CoverageOutputPath = output
-		return nil
-	}
-}
-
-// WithDontRetag disables the Docker image retagging
-func WithDontRetag(dontRetag bool) BuildOption {
-	return func(opts *buildOptions) error {
-		opts.DontRetag = dontRetag
 		return nil
 	}
 }
@@ -568,28 +559,12 @@ func (p *Package) buildDependencies(buildctx *buildContext) (err error) {
 }
 
 func (p *Package) build(buildctx *buildContext) (err error) {
-	artifact, alreadyBuilt := buildctx.LocalCache.Location(p)
+	_, alreadyBuilt := buildctx.LocalCache.Location(p)
 	if p.Ephemeral {
 		// ephemeral packages always require a rebuild
 	} else if alreadyBuilt {
-		// some package types still need to do work even if we find their prior build artifact in the cache.
-		if p.Type == DockerPackage && !buildctx.DontRetag {
-			doBuild := buildctx.ObtainBuildLock(p)
-			if !doBuild {
-				return nil
-			}
-			defer buildctx.ReleaseBuildLock(p)
-
-			err = p.retagDocker(buildctx, filepath.Dir(artifact), artifact)
-			if err != nil {
-				log.WithError(err).Warn("cannot re-use prior build artifact - building afresh.")
-			} else {
-				return
-			}
-		} else {
-			log.WithField("package", p.FullName()).Debug("already built")
-			return nil
-		}
+		log.WithField("package", p.FullName()).Debug("already built")
+		return nil
 	}
 
 	doBuild := buildctx.ObtainBuildLock(p)
@@ -1380,76 +1355,6 @@ func (p *Package) buildGeneric(buildctx *buildContext, wd, result string) (res *
 		BuildCommands:   commands,
 		PackageCommands: [][]string{{"tar", "cfz", result, "."}},
 	}, nil
-}
-
-// retagDocker is called when we already have the build artifact for this package (and version)
-// in the build cache. This function makes sure that if the build arguments changed the name of the
-// Docker image this build time, we just re-tag the image.
-func (p *Package) retagDocker(buildctx *buildContext, wd, prev string) (err error) {
-	buildctx.LimitConcurrentBuilds()
-	defer buildctx.ReleaseConcurrentBuild()
-
-	cfg, ok := p.Config.(DockerPkgConfig)
-	if !ok {
-		return xerrors.Errorf("package should have Docker config")
-	}
-	if len(cfg.Image) == 0 {
-		// this is not a pushed Docker image and as such needs no re-use
-		log.WithField("package", p.FullName()).Debug("already built")
-		return
-	}
-
-	// the previous build artifact should contain the name of the original image. Let's read that name/those names.
-	if _, err := os.Stat(prev); os.IsNotExist(err) {
-		return err
-	}
-	cmd := exec.Command("tar", "Ozfx", prev, "--no-same-owner", dockerImageNamesFiles)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return err
-	}
-	names := strings.Split(string(out), "\n")
-	if len(names) == 0 {
-		return xerrors.Errorf("build artifact is invalid")
-	}
-
-	commands := [][]string{
-		{"docker", "pull", names[0]},
-	}
-	var needsRetagging bool
-	for _, img := range cfg.Image {
-		var found bool
-		for _, nme := range names {
-			if nme == img {
-				found = true
-				break
-			}
-		}
-		if found {
-			continue
-		}
-
-		needsRetagging = true
-		commands = append(commands, [][]string{
-			{"docker", "tag", names[0], img},
-			{"docker", "push", img},
-		}...)
-	}
-	if !needsRetagging {
-		log.WithField("package", p.FullName()).Debug("already built")
-		return
-	}
-
-	buildctx.Reporter.PackageBuildStarted(p)
-	defer func(err *error) {
-		buildctx.Reporter.PackageBuildFinished(p, *err)
-	}(&err)
-
-	err = executeCommandsForPackage(buildctx, p, wd, commands)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func executeCommandsForPackage(buildctx *buildContext, p *Package, wd string, commands [][]string) error {


### PR DESCRIPTION
## Description
Removes the Docker image retagging behaviour from leeway, because Gitpod's no longer using it.

> **Warning**
  This is a breaking change.
