### PR TITLE
Add support for optional depednencies

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -17,6 +17,7 @@ packages:
       - go.sum
     deps:
       - :helloworld
+      - :doesntExist?
     argdeps:
       - version
     prep:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ description: A sentence describing what the script is good for.
 # contains tools you want to use in a script.
 deps:
 - some/other:package
+- some/other:optional?
 # Env sets environment variables which are present during script execution.
 env:
 - MESSAGE=hello

--- a/pkg/leeway/package_test.go
+++ b/pkg/leeway/package_test.go
@@ -6,6 +6,108 @@ import (
 	"testing"
 )
 
+func TestPackageDependencyValid(t *testing.T) {
+	tests := []struct {
+		Input       string
+		Expectation bool
+	}{
+		{":foo", true},
+		{":foo?", true},
+		{"absolute/component:foo?", true},
+		{"missing/package", false},
+		{":", false},
+		{"", false},
+	}
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			act := PackageDependency(test.Input).Valid()
+			if act != test.Expectation {
+				t.Fatalf("expected %v, got %v", test.Expectation, act)
+			}
+		})
+	}
+}
+
+func TestPackageDependencyOptional(t *testing.T) {
+	tests := []struct {
+		Input       string
+		Expectation bool
+	}{
+		{":foo", false},
+		{":foo?", true},
+		{"absolute/component:foo", false},
+		{"absolute/component:foo?", true},
+	}
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			act := PackageDependency(test.Input).Optional()
+			if act != test.Expectation {
+				t.Fatalf("expected %v, got %v", test.Expectation, act)
+			}
+		})
+	}
+}
+
+func TestPackageDependencyRelative(t *testing.T) {
+	tests := []struct {
+		Input       string
+		Expectation bool
+	}{
+		{":foo", true},
+		{":foo?", true},
+		{"absolute/component:foo", false},
+		{"absolute/component:foo?", false},
+	}
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			act := PackageDependency(test.Input).Relative()
+			if act != test.Expectation {
+				t.Fatalf("expected %v, got %v", test.Expectation, act)
+			}
+		})
+	}
+}
+
+func TestPackageDependencyComponent(t *testing.T) {
+	tests := []struct {
+		Input       string
+		Expectation string
+	}{
+		{":foo", ""},
+		{":foo?", ""},
+		{"absolute/component:foo?", "absolute/component"},
+		{"", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			act := PackageDependency(test.Input).Component()
+			if act != test.Expectation {
+				t.Fatalf("expected %v, got %v", test.Expectation, act)
+			}
+		})
+	}
+}
+
+func TestPackageDependencyFullPackage(t *testing.T) {
+	tests := []struct {
+		Input       string
+		Expectation string
+	}{
+		{":foo", ":foo"},
+		{":foo?", ":foo"},
+		{"absolute/component:foo?", "absolute/component:foo"},
+		{"", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			act := PackageDependency(test.Input).FullPackage()
+			if act != test.Expectation {
+				t.Fatalf("expected %v, got %v", test.Expectation, act)
+			}
+		})
+	}
+}
+
 func TestResolveBuiltinVariables(t *testing.T) {
 	tests := []struct {
 		PkgType     PackageType

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -573,12 +573,12 @@ func filterExcludedComponents(variant *PackageVariant, c *Component) (ignoreComp
 
 	for _, p := range c.Packages {
 		for i, dep := range p.Dependencies {
-			segs := strings.Split(dep, ":")
-			if len(segs) != 2 {
+			comp := dep.Component()
+			if comp == "" {
 				continue
 			}
 
-			if variant.ExcludeComponent(segs[0]) {
+			if variant.ExcludeComponent(comp) {
 				p.Dependencies[i] = p.Dependencies[len(p.Dependencies)-1]
 				p.Dependencies = p.Dependencies[:len(p.Dependencies)-1]
 			}
@@ -759,11 +759,11 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 
 		// make all dependencies fully qualified
 		for idx, dep := range pkg.Dependencies {
-			if !strings.HasPrefix(dep, ":") {
+			if !dep.Relative() {
 				continue
 			}
 
-			pkg.Dependencies[idx] = comp.Name + dep
+			pkg.Dependencies[idx] = dep.WithComponent(comp.Name)
 		}
 		// make all layout entries full qualified
 		if pkg.Layout == nil {
@@ -807,11 +807,11 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 
 		// make all dependencies fully qualified
 		for idx, dep := range scr.Dependencies {
-			if !strings.HasPrefix(dep, ":") {
+			if !dep.Relative() {
 				continue
 			}
 
-			scr.Dependencies[idx] = comp.Name + dep
+			scr.Dependencies[idx] = dep.WithComponent(comp.Name)
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR adds support for optional dependencies. This is useful in conjunction with dynamic packages.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #100

## How to test
Have a dependency to a package which doesn't exist and mark it optional, e.g. like in leeways workspace.
