### PR TITLE
Patch gsutil 401 if not logged in

### DIFF
--- a/pkg/leeway/cache.go
+++ b/pkg/leeway/cache.go
@@ -124,8 +124,9 @@ func (rs GSUtilRemoteCache) ExistingPackages(pkgs []*Package) (map[*Package]stru
 	cmd.Stderr = &stderrBuffer
 
 	err := cmd.Run()
-	if err != nil && !strings.Contains(stderrBuffer.String(), "No URLs matched") {
-		return nil, xerrors.Errorf("Failed to check remote cache: [%w]. stderr: [%v]", err, stderrBuffer.String())
+	if err != nil && (!strings.Contains(stderrBuffer.String(), "No URLs matched")) {
+		log.Debugf("gsutil stat returned non-zero exit code: [%v], stderr: [%v]", err, stderrBuffer.String())
+		return map[*Package]struct{}{}, nil
 	}
 
 	existingURLs := parseGSUtilStatOutput(bytes.NewReader(stdoutBuffer.Bytes()))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
quick patch to solve the gsutil permission issue. We should use the client library to talk to GCS, as it will give us a better experience.

Your implementation [here](https://github.com/gitpod-io/leeway/blob/322c71ed69826a9f6da4bcf27e78934c4dfc7ec8/pkg/leeway/cache.go#L125-L136) was handling this @mads-hartmann , I broke it 🙈 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
