### PR TITLE
[go] Log go mod download only when verbose

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1167,7 +1167,12 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 	if cfg.Generate {
 		commands = append(commands, []string{goCommand, "generate", "-v", "./..."})
 	}
-	commands = append(commands, []string{goCommand, "mod", "download", "-x"})
+
+	dlcmd := []string{goCommand, "mod", "download"}
+	if log.IsLevelEnabled(log.DebugLevel) {
+		dlcmd = append(dlcmd, "-x")
+	}
+	commands = append(commands, dlcmd)
 
 	if !cfg.DontCheckGoFmt {
 		commands = append(commands, []string{"sh", "-c", `if [ ! $(go fmt ./... | wc -l) -eq 0 ]; then echo; echo; echo please gofmt your code; echo; echo; exit 1; fi`})


### PR DESCRIPTION
## Description
Logs `go mod download` only when in verbose (debug) mode

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #107

## How to test
- `leeway build -v`
- `leeway build`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Log "go mod download" output only when in verbose mode
```
