### PR TITLE
Remove deprecated Typescript package type

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -106,11 +106,6 @@ Example use:
 			}
 		}
 
-		for i, ft := range filterType {
-			if ft == string(leeway.DeprecatedTypescriptPackage) {
-				filterType[i] = string(leeway.YarnPackage)
-			}
-		}
 		if len(filterType) > 0 {
 			for pkg := range pkgs {
 				var found bool

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -765,14 +765,14 @@ func (p *Package) packagesToDownload(inLocalCache map[*Package]struct{}, inRemot
 
 	var deps []*Package
 	switch p.Type {
-	// For Go and Typescript packages we need all transitive dependencies of a component to be available on disk
+	// For Go and Yarn packages we need all transitive dependencies of a component to be available on disk
 	// to perform a build.
 	//
 	// Example: components/ee/agent-smith:app depends on components/gitpod-protocol/go:lib
 	// 			components/gitpod-protocol/go:lib depends on components/gitpod-protocol:gitpod-schema
 	// 			To build components/ee/agent-smith:app it is not enough to just download components/gitpod-protocol/go:lib
 	// 			as we also need components/gitpod-protocol:gitpod-schema to be available on disk to perform the build.
-	case YarnPackage, GoPackage, DeprecatedTypescriptPackage:
+	case YarnPackage, GoPackage:
 		deps = p.GetTransitiveDependencies()
 	// For Generic and Docker packages it is sufficient to have the direct dependencies.
 	case GenericPackage, DockerPackage:
@@ -821,7 +821,7 @@ rm -r yarn.lock _temp_yarn_cache
 	installerPackageJSONTemplate = `{"name":"local","version":"%s","license":"UNLICENSED","dependencies":{"%s":"%s"}}`
 )
 
-// buildYarn implements the build process for Typescript packages.
+// buildYarn implements the build process for Yarn packages.
 // If you change anything in this process that's not backwards compatible, make sure you increment buildProcessVersions accordingly.
 func (p *Package) buildYarn(buildctx *buildContext, wd, result string) (bld *packageBuild, err error) {
 	cfg, ok := p.Config.(YarnPkgConfig)
@@ -1050,7 +1050,7 @@ func (p *Package) buildYarn(buildctx *buildContext, wd, result string) (bld *pac
 	} else if cfg.Packaging == YarnArchive {
 		pkgCommands = append(pkgCommands, []string{"tar", "cfz", result, "."})
 	} else {
-		return nil, xerrors.Errorf("unknown Typescript packaging: %s", cfg.Packaging)
+		return nil, xerrors.Errorf("unknown Yarn packaging: %s", cfg.Packaging)
 	}
 	res.PackageCommands = pkgCommands
 	res.PostBuild = func(sources fileset) (subjects []in_toto.Subject, absResultDir string, err error) {

--- a/pkg/leeway/format.go
+++ b/pkg/leeway/format.go
@@ -16,9 +16,9 @@ func FormatBUILDyaml(out io.Writer, in io.Reader, fixIssues bool) error {
 	}
 
 	sortPackageDeps(&n)
-	if fixIssues {
-		replaceTypescriptPackageType(&n)
-	}
+	// if fixIssues {
+	// 		right now we have no automatic issue fixes - if this changes, add them here
+	// }
 
 	enc := yaml.NewEncoder(out)
 	enc.SetIndent(2)
@@ -51,70 +51,4 @@ func sortPackageDeps(n *yaml.Node) {
 			sort.Slice(nde.Content, func(i, j int) bool { return nde.Content[i].Value < nde.Content[j].Value })
 		}
 	}
-}
-
-func replaceTypescriptPackageType(n *yaml.Node) {
-	if len(n.Content) < 1 {
-		return
-	}
-
-	nde := n.Content[0]
-	for rootIdx, rootNde := range nde.Content {
-		if rootNde.Value != "packages" || rootIdx == len(nde.Content)-1 {
-			continue
-		}
-
-		nde := nde.Content[rootIdx+1]
-		if len(nde.Content) < 1 {
-			return
-		}
-
-		for _, nde := range nde.Content {
-			tpe := searchInMapFor(nde, "type")
-			if tpe == nil || tpe.Value != string(DeprecatedTypescriptPackage) {
-				continue
-			}
-			tpe.Value = string(YarnPackage)
-
-			nde = searchInMapFor(nde, "config")
-			if nde == nil {
-				continue
-			}
-			nde = searchInMapFor(nde, "commands")
-			if nde == nil {
-				continue
-			}
-			hasBuildCmd := searchInMapFor(nde, "build") != nil
-			if hasBuildCmd {
-				continue
-			}
-			nde.Content = append(nde.Content,
-				&yaml.Node{
-					Kind:  yaml.ScalarNode,
-					Tag:   "!!str",
-					Value: "build",
-				},
-				&yaml.Node{
-					Kind:  yaml.SequenceNode,
-					Tag:   "!!seq",
-					Style: yaml.FlowStyle,
-					Content: []*yaml.Node{
-						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "npx", Style: yaml.DoubleQuotedStyle},
-						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "tsc", Style: yaml.DoubleQuotedStyle},
-					},
-				},
-			)
-		}
-	}
-}
-
-func searchInMapFor(nde *yaml.Node, key string) (val *yaml.Node) {
-	for pkgIdx, pkgNde := range nde.Content {
-		if pkgNde.Value != key || pkgIdx == len(nde.Content)-1 {
-			continue
-		}
-
-		return nde.Content[pkgIdx+1]
-	}
-	return nil
 }

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -352,8 +352,6 @@ func (p *Package) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func unmarshalTypeDependentConfig(tpe PackageType, unmarshal func(interface{}) error) (PackageConfig, error) {
 	switch tpe {
-	case DeprecatedTypescriptPackage:
-		fallthrough
 	case YarnPackage:
 		var cfg struct {
 			Config YarnPkgConfig `yaml:"config"`
@@ -549,9 +547,6 @@ func (cfg GenericPkgConfig) AdditionalSources(workspaceOrigin string) []string {
 type PackageType string
 
 const (
-	// DeprecatedTypescriptPackage runs tsc in a package and produces a yarn offline mirror
-	DeprecatedTypescriptPackage PackageType = "typescript"
-
 	// YarnPackage uses the yarn package manager to download dependencies and build the package
 	YarnPackage PackageType = "yarn"
 
@@ -575,7 +570,7 @@ func (p *PackageType) UnmarshalYAML(unmarshal func(interface{}) error) (err erro
 
 	*p = PackageType(val)
 	switch *p {
-	case DeprecatedTypescriptPackage, YarnPackage, GoPackage, DockerPackage, GenericPackage:
+	case YarnPackage, GoPackage, DockerPackage, GenericPackage:
 	default:
 		return fmt.Errorf("invalid package type: %s", err)
 	}

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -585,10 +585,6 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 
 	for i, pkg := range comp.Packages {
 		pkg.C = &comp
-		if pkg.Type == "typescript" {
-			log.WithField("pkg", pkg.FullName()).Warn("package uses deprecated \"typescript\" type - use \"yarn\" instead")
-			pkg.Type = YarnPackage
-		}
 
 		pkg.Definition, err = yaml.Marshal(&rawcomp.Packages[i])
 		if err != nil {

--- a/pkg/vet/yarn.go
+++ b/pkg/vet/yarn.go
@@ -12,36 +12,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
-	"gopkg.in/yaml.v3"
 
 	"github.com/gitpod-io/leeway/pkg/leeway"
 )
 
 func init() {
-	register(PackageCheck("deprecated-type", "checks if the package uses the deprecated typescript type", leeway.YarnPackage, checkYarnDeprecatedType))
 	register(&checkImplicitTransitiveDependencies{})
-}
-
-func checkYarnDeprecatedType(pkg *leeway.Package) ([]Finding, error) {
-	var rp struct {
-		Type string `yaml:"type"`
-	}
-	err := yaml.Unmarshal(pkg.Definition, &rp)
-	if err != nil {
-		return nil, err
-	}
-
-	if rp.Type == string(leeway.DeprecatedTypescriptPackage) {
-		return []Finding{
-			{
-				Description: "package uses deprecated \"typescript\" type - use \"yarn\" instead (run `leeway fmt -fi` to fix this)",
-				Component:   pkg.C,
-				Package:     pkg,
-			},
-		}, nil
-	}
-
-	return nil, nil
 }
 
 type pkgJSON struct {


### PR DESCRIPTION
## Description
Removes the long deprecated typescript package type.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #123

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[breaking] Remove deprecated `typescript` package type
```
