### PR TITLE
Add vet for node_module source inclusion

### DIFF
--- a/pkg/vet/components.go
+++ b/pkg/vet/components.go
@@ -17,6 +17,10 @@ func checkComponentsFmt(comp *leeway.Component) ([]Finding, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(fc) == 0 {
+		// empty BUILD.yaml files are ok
+		return nil, nil
+	}
 
 	buf := bytes.NewBuffer(nil)
 	err = leeway.FormatBUILDyaml(buf, bytes.NewReader(fc), false)

--- a/pkg/vet/docker_test.go
+++ b/pkg/vet/docker_test.go
@@ -59,7 +59,7 @@ ADD from-some-pkg--build/hello.txt hello.txt`,
 
 			tmpdir, err := os.MkdirTemp("", "leeway-test-*")
 			failOnErr(err)
-			// defer os.RemoveAll(tmpdir)
+			defer os.RemoveAll(tmpdir)
 
 			var pkgdeps string
 			failOnErr(os.WriteFile(filepath.Join(tmpdir, "WORKSPACE.yaml"), []byte("environmentManifest:\n  - name: \"docker\"\n    command: [\"echo\"]"), 0644))

--- a/pkg/vet/vet.go
+++ b/pkg/vet/vet.go
@@ -190,7 +190,7 @@ func Run(workspace leeway.Workspace, options ...RunOpt) ([]Finding, []error) {
 	for _, check := range checks {
 		err := check.Init(workspace)
 		if err != nil {
-			return nil, []error{err}
+			return nil, []error{fmt.Errorf("init %s: %w", check.Info().Name, err)}
 		}
 	}
 
@@ -207,7 +207,7 @@ func Run(workspace leeway.Workspace, options ...RunOpt) ([]Finding, []error) {
 			log.WithField("check", info.Name).WithField("cmp", comp.Name).Debug("running component check")
 			f, err := c.RunCmp(comp)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("%s: %w", comp.Name, err))
+				errs = append(errs, fmt.Errorf("[%s] %s: %w", info.Name, comp.Name, err))
 				return
 			}
 			for i := range f {
@@ -228,7 +228,7 @@ func Run(workspace leeway.Workspace, options ...RunOpt) ([]Finding, []error) {
 			log.WithField("check", info.Name).WithField("pkg", pkg.FullName()).Debug("running package check")
 			f, err := c.RunPkg(pkg)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("%s: %w", pkg.FullName(), err))
+				errs = append(errs, fmt.Errorf("[%s] %s: %w", info.Name, pkg.FullName(), err))
 				return
 			}
 			for i := range f {


### PR DESCRIPTION
## Description
Add vet for node_module source inclusion and fix two minor issues around vet:
- better details when a vet check fails
- support build `BUILD.js` for the `fmt` vet

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #126

## How to test
Run `leeway vet` on a package which includes `node_modules`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[vet] Minor bug fixes
[vet] New check for Yarn packages which include `node_modules/` in their sources
```
