### PR TITLE
[go] Add golangci-lint to the env manifest

### DIFF
--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -134,6 +134,7 @@ var defaultEnvManifestEntries = map[PackageType]EnvironmentManifest{
 	},
 	GoPackage: []EnvironmentManifestEntry{
 		{Name: "go", Command: []string{"go", "version"}},
+		{Name: "golangci-lint", Command: []string{"golangci-lint", "version"}},
 	},
 	YarnPackage: []EnvironmentManifestEntry{
 		{Name: "yarn", Command: []string{"yarn", "-v"}},


### PR DESCRIPTION
## Description
Adds golangci-lint to the env manifest.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #132

## How to test
```
leeway describe environment-manifest
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add golangci-lint to the version manifest
```
