### PR TITLE
[docker] Support daisy-chaining Docker packages

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1296,10 +1296,12 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 		ef := strings.TrimSuffix(result, ".gz")
 		res.PostBuild = dockerExportPostBuild(wd, ef)
 
-		res.PackageCommands = [][]string{
-			{"tar", "fr", ef, "./" + provenanceBundleFilename},
-			{"gzip", ef},
+		var pkgcmds [][]string
+		if p.C.W.Provenance.Enabled {
+			pkgcmds = append(pkgcmds, []string{"tar", "fr", ef, "./" + provenanceBundleFilename})
 		}
+		pkgcmds = append(pkgcmds, []string{"gzip", ef})
+		res.PackageCommands = pkgcmds
 	} else if len(cfg.Image) > 0 {
 		for _, img := range cfg.Image {
 			pkgCommands = append(pkgCommands, [][]string{

--- a/pkg/leeway/package_test.go
+++ b/pkg/leeway/package_test.go
@@ -309,3 +309,23 @@ func NewTestPackage(name string) *Package {
 		Config:       GenericPkgConfig{},
 	}
 }
+
+func TestCodecovComponentName(t *testing.T) {
+	tests := []struct {
+		Test     string
+		Package  string
+		Expected string
+	}{
+		{"valid package format", "components/ee/ws-scheduler", "components-ee-ws-scheduler-coverage.out"},
+		{"lower case", "COMPONENTS/gitpod-cli:app", "components-gitpod-cli-app-coverage.out"},
+		{"special character", "components/~ü:app", "components-app-coverage.out"},
+		{"with numbers", "components/1icens0r:app", "components-1icens0r-app-coverage.out"},
+	}
+
+	for _, test := range tests {
+		name := codecovComponentName(test.Package)
+		if name != test.Expected {
+			t.Errorf("%s: expected: %v, actual: %v", test.Test, test.Expected, name)
+		}
+	}
+}

--- a/pkg/leeway/scripts_test.go
+++ b/pkg/leeway/scripts_test.go
@@ -141,7 +141,7 @@ func (ft *CommandFixtureTest) Run() {
 				t.Fatalf("cannot materialize fixture: %v", err)
 			}
 			t.Logf("materialized fixture workspace: %s", loc)
-			t.Cleanup(func() { os.RemoveAll(loc) })
+			// t.Cleanup(func() { os.RemoveAll(loc) })
 		}
 
 		env := os.Environ()

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -78,6 +79,20 @@ func (s Setup) Materialize() (workspaceRoot string, err error) {
 		err = os.WriteFile(filepath.Join(workspaceRoot, comp.Location, "BUILD.yaml"), fc, 0644)
 		if err != nil {
 			return
+		}
+
+		for fn, content := range comp.Files {
+			err = os.MkdirAll(filepath.Join(workspaceRoot, comp.Location, filepath.Dir(fn)), 0755)
+			if errors.Is(err, os.ErrExist) {
+				err = nil
+			}
+			if err != nil {
+				return
+			}
+			err = os.WriteFile(filepath.Join(workspaceRoot, comp.Location, fn), []byte(content), 0644)
+			if err != nil {
+				return
+			}
 		}
 	}
 

--- a/pkg/testutil/testutil_test.go
+++ b/pkg/testutil/testutil_test.go
@@ -97,8 +97,9 @@ func TestMaterialise(t *testing.T) {
 					{
 						Location: "comp1",
 						Files: map[string]string{
-							"someFile":        "content",
-							"some/other/file": "more content",
+							"someFile":           "content",
+							"some/other/file":    "more content",
+							"some/other/another": "more content",
 						},
 						Comp: leeway.Component{
 							Constants: leeway.Arguments{


### PR DESCRIPTION
## Description
This change allows the reuse of previously built Docker images in subsequent packages, e.g.

comp/BUILD.yaml:
```
packages:
  - name: pkg0
    type: docker
    config:
      dockerfile: pkg0.Dockerfile
      image: 
        - "foobar:latest"
  - name: pkg1
    type: docker
    deps:
      - :pkg0
    config:
      Dockerfile: pkg1.Dockerfile
```

comp/pkg1.Dockerfile
```
FROM ${DEP_COMP__PKG0}

RUN echo using prior image as base
```

We want to use this in dedicated to build a base image for functions, and refer to it in subsequent packages.


## How to test
See test in this PR
