### PR TITLE
[go] Support "nested" Go main builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ config:
   buildFlags: []
   # Command that's executed to lint the code
   lintCommand: ["golangci-lint", "run"]
+  # GoMod can point to a go.mod file outside the component root. Leeway expects a go.sum alongside the go.mod.
+  goMod: "../go.mod"
 ```
 
 ### Yarn packages
@@ -172,6 +174,14 @@ config:
   - gitpod/leeway:latest
   - gitpod/leeway:${__pkg_version}
 ```
+
+The first image name of each Docker dependency which pushed an image will result in a build argument. This mechanism enables a package to build the base image for another one, by using the build argument as `FROM` value.
+The name of this build argument is the package name of the dependency, transformed as follows:
+- `/` is replaced with `_`
+- `:` is replaced with `__`
+- all uppercase.
+
+E.g. `component/nested:docker` becomes `COMPONENT_NESTED__DOCKER`.
 
 ### Generic packages
 ```YAML

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1078,7 +1078,7 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 		return nil, xerrors.Errorf("package should have Go config")
 	}
 
-	if _, err := os.Stat(filepath.Join(p.C.Origin, "go.mod")); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(wd, "go.mod")); os.IsNotExist(err) {
 		return nil, xerrors.Errorf("can only build Go modules (missing go.mod file)")
 	}
 

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -613,7 +613,7 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 			}
 
 			if _, err := os.Stat(fn); os.IsNotExist(err) {
-				return comp, xerrors.Errorf("%s: %w", comp.Name, err)
+				return comp, xerrors.Errorf("cannot find additional source for %s: %w", comp.Name, err)
 			}
 			if _, found := completeSources[fn]; found {
 				continue


### PR DESCRIPTION
## Description
This change allows leeway to build "muti-main" Go projects. Before this change one would have to produce multiple packages at the root of a Go module. With this change we can have multiple leeway components within the same Go module. 

### Possible now

```
foobar
├── go.mod
├── go.sum
└── cmd
    ├── hello
    │   ├── main.go
    │   └── BUILD.yaml
    └── world
        ├── main.go
        └── BUILD.yaml
```

Where the `BUILD.yaml` looks like this:
```yaml
packages:
  - name: app
    type: go
    srcs:
      - main.go
    config:
      goMod: ../go.mod
```

### Before this change

```
foobar
├── go.mod
├── go.sum
├── BUILD.yaml
└── cmd
    ├── hello
    │   ├── main.go
    └── world
        ├── main.go
```

Where the `BUILD.yaml` looks like this:
```yaml
packages:
  - name: hello
    type: go
    srcs:
      - go.mod
      - go.sum
      - hello/*.go
    prepare:
      - ["mv", "hello/main.go", "."]
  - name: world
    type: go
    srcs:
      - go.mod
      - go.sum
      - world/*.go
    prepare:
      - ["mv", "world/main.go", "."]
```
