### PR TITLE
Add support for local default arg overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ defaultArgs:
   key: value
 ```
 
+Users can override, and provide additional default arguments using a `WORKSPACE.args.yaml` file in the workspace root. This is useful for providing local overrides which you might not want to commit to Git.
+The `WORKSPACE.args.yaml` takes key value pairs which become available as build arguments. The values herein take precedence over the default arguments in the `WORKSPACE.yaml`.
+
+```YAML
+foo: bar
+key: value
+```
+
 ## Component
 Place a `BUILD.yaml` in a folder somewhere in the workspace to make that folder a component. A `BUILD.yaml` primarily contains the packages of that components, but can also contain constant values (think of them as metadata). For example:
 ```YAML

--- a/pkg/leeway/workspace_test.go
+++ b/pkg/leeway/workspace_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gitpod-io/leeway/pkg/leeway"
 	"github.com/gitpod-io/leeway/pkg/testutil"
 )
 
@@ -32,6 +33,38 @@ func TestFixtureLoadWorkspace(t *testing.T) {
 			ExitCode:          0,
 			StdoutSubs:        []string{"deeper/pkg0\nwsa\nwsa/pkg0\nwsa/pkg1"},
 			FixturePath:       "fixtures/load-workspace.yaml",
+		},
+		{
+			Name:              "workspace args file",
+			T:                 t,
+			Args:              []string{"describe", "comp:pkg"},
+			NoNestedWorkspace: true,
+			ExitCode:          0,
+			StdoutSubs:        []string{"foobar"},
+			Fixture: &testutil.Setup{
+				Files: map[string]string{"WORKSPACE.args.yaml": "msg: foobar"},
+				Workspace: leeway.Workspace{
+					ArgumentDefaults: map[string]string{
+						"msg": "blabla",
+					},
+				},
+				Components: []testutil.Component{
+					{
+						Location: "comp",
+						Packages: []leeway.Package{
+							{
+								PackageInternal: leeway.PackageInternal{
+									Name: "pkg",
+									Type: leeway.GenericPackage,
+								},
+								Config: leeway.GenericPkgConfig{
+									Commands: [][]string{{"echo", "${msg}"}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "environment manifest",

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -17,8 +17,9 @@ import (
 )
 
 type Setup struct {
-	Workspace  leeway.Workspace `yaml:"workspace"`
-	Components []Component      `yaml:"components"`
+	Workspace  leeway.Workspace  `yaml:"workspace"`
+	Components []Component       `yaml:"components"`
+	Files      map[string]string `yaml:"files"`
 }
 
 type Component struct {
@@ -59,6 +60,20 @@ func (s Setup) Materialize() (workspaceRoot string, err error) {
 	err = os.WriteFile(filepath.Join(workspaceRoot, "WORKSPACE.yaml"), fc, 0644)
 	if err != nil {
 		return
+	}
+	for fn, content := range s.Files {
+		fn = filepath.Join(workspaceRoot, fn)
+		err = os.MkdirAll(filepath.Dir(fn), 0755)
+		if errors.Is(err, os.ErrExist) {
+			err = nil
+		}
+		if err != nil {
+			return
+		}
+		err = os.WriteFile(fn, []byte(content), 0644)
+		if err != nil {
+			return
+		}
 	}
 
 	for _, comp := range s.Components {


### PR DESCRIPTION
## Description
This PR adds support for a new `WORKSPACE.args.yaml` which carries default argument overrides. This is useful to adapt a local workspace without committing values to Git.

## How to test
See unit test.
