### PR TITLE
[cmd] add completions for collect, validate collect args

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -29,9 +29,10 @@ type variantDescription struct {
 
 // collectCmd represents the collect command
 var collectCmd = &cobra.Command{
-	Use:   "collect [components|packages|scripts|files]",
-	Short: "Collects all packages in a workspace",
-	Args:  cobra.MaximumNArgs(1),
+	Use:       "collect [components|packages|scripts|files]",
+	Short:     "Collects all packages in a workspace",
+	Args:      cobra.MatchAll(cobra.OnlyValidArgs, cobra.MaximumNArgs(1)),
+	ValidArgs: []string{"components", "packages", "scripts", "scripts", "files"},
 	Run: func(cmd *cobra.Command, args []string) {
 		workspace, err := getWorkspace()
 		if err != nil {


### PR DESCRIPTION
## Description

This adds shell completions for `cmd/collect` and adds argument validation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

```bash
gitpod /workspace/leeway (alt/collect-completions-validations) $ ./leeway collect <TAB> <TAB>
components  files       packages    scripts     
gitpod /workspace/leeway (alt/collect-completions-validations) $ ./leeway collect
```

```bash
gitpod /workspace/leeway (alt/collect-completions-validations) $ ./leeway collect flies
Error: invalid argument "flies" for "leeway collect"
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[cmd] Validate collect args, add collect arg completion
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
