### PR TITLE
Add docker image results to the HTML report

### DIFF
--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -397,7 +397,7 @@ func (r *HTMLReporter) Report() {
 {{- range $pkg, $report := .Packages }}
 <h2 id="{{ $pkg }}">{{ $pkg }}</h2>
 {{ if $report.HasError -}}
-<details>
+<details open> 
 	<summary>Error message</summary>
 	<pre><code>{{ $report.Error }}</code></pre>
 </details>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add docker image results to the HTML report

This also changes the structure of the report so that it starts with a `<table>` that provides a quick overview of the packages that were built. Each row also contains a link to further down in the report as each package now has a separate `<h2>` section with details about the package. This makes it easier to add more details as we go without loosing the nice concise overview

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15485

## How to test
<!-- Provide steps to test this PR -->

I tested this in gitpod-io/gitpod. Here's the screenshot.

![Screenshot 2022-12-22 at 13 58 59](https://user-images.githubusercontent.com/83561/209140293-438d0a4a-e8d8-4d6c-81e1-30327edd3f55.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
HTML report has been improved and extended to include results for any docker images that were built
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A