### PR TITLE
Use v1.13.1 as that was the version used in the last successful release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.13.1
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

[GoReleaser is failing](https://github.com/gitpod-io/leeway/actions/runs/3828388013). with `failed to build for windows_amd64_v1: exit status 2` and `2023-01-03T09:46:38.4942225Z ##[error]../../../go/pkg/mod/github.com/opencontainers/runc@v1.1.4/libcontainer/devices/device.go:173:9: undefined: mkDev`


 We're using "latest" which is currently v1.14.1 - it is only 18 hours old. Maybe is contains a regressions. The [last succesful release](https://github.com/gitpod-io/leeway/actions/runs/3684651081/jobs/6234636719) was using v1.13.1 so lets give that a try.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue.

## How to test
<!-- Provide steps to test this PR -->

Merge into main and re-run the job.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A
