### PR TITLE
[cache] extract push/pull cache defs to cache.go

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -185,9 +185,9 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 	case leeway.CacheNone, leeway.CacheLocal:
 		remoteCache = leeway.NoRemoteCache{}
 	case leeway.CacheRemotePull:
-		remoteCache = &pullOnlyRemoteCache{C: remoteCache}
+		remoteCache = &leeway.PullOnlyRemoteCache{C: remoteCache}
 	case leeway.CacheRemotePush:
-		remoteCache = &pushOnlyRemoteCache{C: remoteCache}
+		remoteCache = &leeway.PushOnlyRemoteCache{C: remoteCache}
 	case leeway.CacheRemote:
 	default:
 		log.Fatalf("invalid cache level: %s", cacheLevel)
@@ -293,36 +293,4 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		leeway.WithDockerBuildOptions(&dockerBuildOptions),
 		leeway.WithJailedExecution(jailedExecution),
 	}, localCache
-}
-
-type pushOnlyRemoteCache struct {
-	C leeway.RemoteCache
-}
-
-func (c *pushOnlyRemoteCache) ExistingPackages(pkgs []*leeway.Package) (map[*leeway.Package]struct{}, error) {
-	return c.C.ExistingPackages(pkgs)
-}
-
-func (c *pushOnlyRemoteCache) Download(dst leeway.Cache, pkgs []*leeway.Package) error {
-	return nil
-}
-
-func (c *pushOnlyRemoteCache) Upload(src leeway.Cache, pkgs []*leeway.Package) error {
-	return c.C.Upload(src, pkgs)
-}
-
-type pullOnlyRemoteCache struct {
-	C leeway.RemoteCache
-}
-
-func (c *pullOnlyRemoteCache) ExistingPackages(pkgs []*leeway.Package) (map[*leeway.Package]struct{}, error) {
-	return c.C.ExistingPackages(pkgs)
-}
-
-func (c *pullOnlyRemoteCache) Download(dst leeway.Cache, pkgs []*leeway.Package) error {
-	return c.C.Download(dst, pkgs)
-}
-
-func (c *pullOnlyRemoteCache) Upload(src leeway.Cache, pkgs []*leeway.Package) error {
-	return nil
 }

--- a/pkg/leeway/cache.go
+++ b/pkg/leeway/cache.go
@@ -98,6 +98,40 @@ func (NoRemoteCache) Upload(src Cache, pkgs []*Package) error {
 	return nil
 }
 
+// PushOnlyRemoteCache implements a remote cache that will only push packages to the cache
+type PushOnlyRemoteCache struct {
+	C RemoteCache
+}
+
+func (c *PushOnlyRemoteCache) ExistingPackages(pkgs []*Package) (map[*Package]struct{}, error) {
+	return c.C.ExistingPackages(pkgs)
+}
+
+func (c *PushOnlyRemoteCache) Download(dst Cache, pkgs []*Package) error {
+	return nil
+}
+
+func (c *PushOnlyRemoteCache) Upload(src Cache, pkgs []*Package) error {
+	return c.C.Upload(src, pkgs)
+}
+
+// PullOnlyRemoteCache implements a remote cache that will only pull packages from the cache
+type PullOnlyRemoteCache struct {
+	C RemoteCache
+}
+
+func (c *PullOnlyRemoteCache) ExistingPackages(pkgs []*Package) (map[*Package]struct{}, error) {
+	return c.C.ExistingPackages(pkgs)
+}
+
+func (c *PullOnlyRemoteCache) Download(dst Cache, pkgs []*Package) error {
+	return c.C.Download(dst, pkgs)
+}
+
+func (c *PullOnlyRemoteCache) Upload(src Cache, pkgs []*Package) error {
+	return nil
+}
+
 // GSUtilRemoteCache uses the gsutil command to implement a remote cache
 type GSUtilRemoteCache struct {
 	BucketName string


### PR DESCRIPTION
## Description

This pull request colocates the pushonly and pullonly remote cache definitions alongside the other cache definitions; colocating these structs slightly improves the locality of caching logic.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
