### PR TITLE
Only use buildContext when building packages

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -456,14 +456,14 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 		pkgsToDownload = append(pkgsToDownload, p)
 	}
 
-	err = options.RemoteCache.Download(ctx.LocalCache, pkgsToDownload)
+	err = ctx.RemoteCache.Download(ctx.LocalCache, pkgsToDownload)
 	if err != nil {
 		return err
 	}
 
-	options.Reporter.BuildStarted(pkg, pkgstatus)
+	ctx.Reporter.BuildStarted(pkg, pkgstatus)
 	defer func(err *error) {
-		options.Reporter.BuildFinished(pkg, *err)
+		ctx.Reporter.BuildFinished(pkg, *err)
 	}(&err)
 
 	if len(unresolvedArgs) != 0 {
@@ -475,21 +475,21 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 		return xerrors.Errorf(msg)
 	}
 
-	if options.BuildPlan != nil {
+	if ctx.BuildPlan != nil {
 		log.Debug("writing build plan")
-		err = writeBuildPlan(options.BuildPlan, pkg, pkgstatus)
+		err = writeBuildPlan(ctx.BuildPlan, pkg, pkgstatus)
 		if err != nil {
 			return err
 		}
 	}
 
-	if options.DryRun {
+	if ctx.DryRun {
 		// This is a dry-run. We've prepared everything for the build but do not execute the build itself.
 		return nil
 	}
 
 	buildErr := pkg.build(ctx)
-	cacheErr := options.RemoteCache.Upload(ctx.LocalCache, ctx.GetNewPackagesForCache())
+	cacheErr := ctx.RemoteCache.Upload(ctx.LocalCache, ctx.GetNewPackagesForCache())
 
 	if buildErr != nil {
 		// We deliberately swallow the target pacakge build error as that will have already been reported using the reporter.


### PR DESCRIPTION
## Description

pkg/build.Build may be called with a BuildOptions that contains a pre-generated BuildContext; in this case the BuildOptions value is largely ignored during context setup and may not be complete. The buildContext struct will be authoritative in this context and must be be used instead of buildOptions.

One way that this issue manifests is when running a leeway script with dependencies as `leeway run` generates a buildContext and passes that into leeway.Build; the rest of the buildOptions is empty. When using buildOptions the RemoteCache field will always be empty, even if the buildContext value has a RemoteCache defined. By only using buildContext instead of buildOptions we resolve this confusion on what data is authoritative.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Add the following to `BUILD.yaml`, configure a remote cache (AWS or GCP), and build a package. Before this change the package dependencies would not be cached; after the cache will be downloaded from/uploaded to.

```yaml
scripts:
  - name: test
    deps:
      - //:app
    script: |
      echo hello world
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[cmd/run] Respect remote cache when building script dependencies
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
