### PR TITLE
Allow const as argdep

### DIFF
--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -531,6 +531,7 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 	for k, v := range compconst.Constants {
 		// constants overwrite args
 		compargs[k] = v
+		log.WithField("comp", path).WithField("const", k).Debug("using const as arg")
 	}
 
 	// replace build args
@@ -660,7 +661,10 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 
 		// re-set the version relevant arguments to <name>: <value>
 		for i, argdep := range pkg.ArgumentDependencies {
-			val, ok := args[argdep]
+			val, ok := pkg.C.Constants[argdep]
+			if !ok {
+				val, ok = args[argdep]
+			}
 			if !ok {
 				val = "<not-set>"
 			}


### PR DESCRIPTION
## Description
Prior to this change the following component would not build without passing `foobar` as build arg:

```YAML
const:
  - foobar=baz
packages:
  - name: demo
    type: generic
    argdeps:
      - foobar
```
