### PR TITLE
Fail helpfully when running on mac

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -396,6 +396,11 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 		return err
 	}
 
+	err = checkForCpCompatibility()
+	if err != nil {
+		return err
+	}
+
 	requirements := pkg.GetTransitiveDependencies()
 	allpkg := append(requirements, pkg)
 

--- a/pkg/leeway/build_darwin.go
+++ b/pkg/leeway/build_darwin.go
@@ -2,7 +2,28 @@ package leeway
 
 import (
 	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
+
+func checkForCpCompatibility() error {
+	out, err := exec.Command("cp", "--help").CombinedOutput()
+	if err != nil && !strings.Contains(err.Error(), "exit") {
+		log.WithError(err).Debug("cannot check if cp is compatible")
+		// if cp is not compatible we'll fail later in the build,
+		// but maybe it is and we don't want to fail here for no good reason.
+		return nil
+	}
+
+	if strings.Contains(string(out), "--parents") {
+		// we're good
+		return nil
+	}
+
+	return fmt.Errorf("leeway requires a GNU-compatible cp. Please install using `brew install coreutils`; make sure you update your PATH after installing.")
+}
 
 func executeCommandsForPackageSafe(buildctx *buildContext, p *Package, wd string, commands [][]string) error {
 	return fmt.Errorf("not implemented")

--- a/pkg/leeway/build_linux.go
+++ b/pkg/leeway/build_linux.go
@@ -14,6 +14,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func checkForCpCompatibility() error {
+	// we're on linux - just assume it's GNU cp
+	return nil
+}
+
 func executeCommandsForPackageSafe(buildctx *buildContext, p *Package, wd string, commands [][]string) error {
 	tmpdir, err := os.MkdirTemp("", "leeway-*")
 	if err != nil {


### PR DESCRIPTION
## Description
I.e. produces the following when running on mac without GNU compatible cp:
```
FATA[0000] leeway requires a GNU-compatible cp. Please install using `brew install coreutils`; make sure you update your path after installing.
```
