### PR TITLE
Discover workspace root

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "leeway",
+	"image": "mcr.microsoft.com/devcontainers/go:1.21",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,7 +131,14 @@ func Execute() {
 func init() {
 	workspaceRoot := os.Getenv(EnvvarWorkspaceRoot)
 	if workspaceRoot == "" {
-		workspaceRoot = "."
+		var err error
+		workspaceRoot, err = leeway.DiscoverWorkspaceRoot()
+		if err != nil {
+			log.WithError(err).Debug("cannot determine workspace root - defaulting to .")
+			workspaceRoot = "."
+		} else {
+			log.WithField("workspace", workspaceRoot).Debug("found workspace root")
+		}
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&workspace, "workspace", "w", workspaceRoot, "Workspace root")

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -58,6 +58,26 @@ type WorkspaceProvenance struct {
 	key     *in_toto.Key `yaml:"-"`
 }
 
+func DiscoverWorkspaceRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < 100; i++ {
+		if _, err := os.Stat(filepath.Join(wd, "WORKSPACE.yaml")); err == nil {
+			return wd, nil
+		}
+
+		wd = filepath.Dir(wd)
+		if wd == "/" || wd == "" {
+			break
+		}
+	}
+
+	return "", xerrors.Errorf("cannot find workspace root")
+}
+
 // EnvironmentManifest is a collection of environment manifest entries
 type EnvironmentManifest []EnvironmentManifestEntry
 


### PR DESCRIPTION
## Description
This PR makes leeway automatically discover the workspace route by traveling up the path all the way to the root of the file system and looking for a WORKSPACE.yaml file.
