### PR TITLE
Go build fixes

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1283,8 +1283,8 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 	if len(buildCmd) > 0 && cfg.Packaging != GoLibrary {
 		commands[PackageBuildPhaseBuild] = append(commands[PackageBuildPhaseBuild], buildCmd)
 	}
-	commands[PackageBuildPhaseBuild] = append(commands[PackageBuildPhaseBuild], []string{"rm", "-rf", "_deps"})
 
+	commands[PackageBuildPhasePackage] = append(commands[PackageBuildPhasePackage], []string{"rm", "-rf", "_deps"})
 	commands[PackageBuildPhasePackage] = append(commands[PackageBuildPhasePackage], []string{
 		"tar", "cf", result, fmt.Sprintf("--use-compress-program=%v", compressor), ".",
 	})

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1265,7 +1265,7 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 			testCommand = append(testCommand, fmt.Sprintf("-coverprofile=%v", codecovComponentName(p.FullName())))
 		} else {
 			testCommand = append(testCommand, "-coverprofile=testcoverage.out")
-			reportCoverage = collectGoTestCoverage(filepath.Join(wd, "testcoverage.out"), p.FullName())
+			reportCoverage = collectGoTestCoverage(filepath.Join(wd, "testcoverage.out"))
 		}
 		testCommand = append(testCommand, "./...")
 
@@ -1300,7 +1300,7 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 	}, nil
 }
 
-func collectGoTestCoverage(covfile, fullName string) testCoverageFunc {
+func collectGoTestCoverage(covfile string) testCoverageFunc {
 	return func() (coverage, funcsWithoutTest, funcsWithTest int, err error) {
 		// We need to collect the coverage for all packages in the module.
 		// To that end we load the coverage file.
@@ -1680,6 +1680,7 @@ func executeCommandsForPackage(buildctx *buildContext, p *Package, wd string, co
 	}
 
 	env := append(os.Environ(), p.Environment...)
+	env = append(env, fmt.Sprintf("LEEWAY_WORKSPACE_ROOT=%s", p.C.W.Origin))
 	for _, cmd := range commands {
 		err := run(buildctx.Reporter, p, env, wd, cmd[0], cmd[1:]...)
 		if err != nil {


### PR DESCRIPTION
## Description
This PR makes LEEWAY_WORKSPACE_ROOT available for commands executed during build. This way one can refer to e.g. config files in lint or test commands.

It also fixes a regression for test coverage collection which would affect Go packages referencing other go dependencies, when using Go workspaces.
