### PR TITLE
Add flag to not compress generic builds

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -168,6 +168,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().String("dump-plan", "", "Writes the build plan as JSON to a file. Use \"-\" to write the build plan to stderr.")
 	cmd.Flags().Bool("werft", false, "Produce werft CI compatible output")
 	cmd.Flags().Bool("dont-test", false, "Disable all package-level tests (defaults to false)")
+	cmd.Flags().Bool("dont-compress", false, "Disable compression of build artifacts (defaults to false)")
 	cmd.Flags().Bool("jailed-execution", false, "Run all build commands using runc (defaults to false)")
 	cmd.Flags().UintP("max-concurrent-tasks", "j", uint(runtime.NumCPU()), "Limit the number of max concurrent build tasks - set to 0 to disable the limit")
 	cmd.Flags().String("coverage-output-path", "", "Output path where test coverage file will be copied after running tests")
@@ -288,6 +289,11 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		log.Fatal(err)
 	}
 
+	dontCompress, err := cmd.Flags().GetBool("dont-compress")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return []leeway.BuildOption{
 		leeway.WithLocalCache(localCache),
 		leeway.WithRemoteCache(remoteCache),
@@ -299,6 +305,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		leeway.WithCoverageOutputPath(coverageOutputPath),
 		leeway.WithDockerBuildOptions(&dockerBuildOptions),
 		leeway.WithJailedExecution(jailedExecution),
+		leeway.WithCompressionDisabled(dontCompress),
 	}, localCache
 }
 

--- a/pkg/leeway/cache.go
+++ b/pkg/leeway/cache.go
@@ -57,12 +57,31 @@ func (fsc *FilesystemCache) Location(pkg *Package) (path string, exists bool) {
 		return "", false
 	}
 
-	fn := filepath.Join(fsc.Origin, fmt.Sprintf("%s.tar.gz", version))
-	if _, err := os.Stat(fn); os.IsNotExist(err) {
-		return fn, false
+	// Check for .tar.gz file first
+	gzPath := filepath.Join(fsc.Origin, fmt.Sprintf("%s.tar.gz", version))
+	if fileExists(gzPath) {
+		return gzPath, true
 	}
 
-	return fn, true
+	// Fall back to .tar file
+	tarPath := filepath.Join(fsc.Origin, fmt.Sprintf("%s.tar", version))
+	exists = fileExists(tarPath)
+
+	return tarPath, exists
+}
+
+// fileExists checks if a file exists and is not a directory
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+
+		return false
+	}
+
+	return !info.IsDir()
 }
 
 // RemoteCache can download and upload build artifacts into a local cache


### PR DESCRIPTION
## Description

Add new flag `--dont-compress` to improve build times of already compressed assets.
