### PR TITLE
Update goreleaser and remove i386

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*" # triggers only if push new tag version, like `0.8.4` or else
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -16,7 +19,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.4"
+          go-version: "1.23"
       - name: Docker Login
         uses: docker/login-action@v1
         with:
@@ -24,10 +27,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           distribution: goreleaser
-          version: v1.13.1
+          version: v2.3.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,24 +2,23 @@ before:
   hooks:
     - go generate ./...
 builds:
-- env:
-  - CGO_ENABLED=0
-  ldflags:
-  - -s -w -X github.com/gitpod-io/leeway/pkg/leeway.Version={{.Version}}-{{.ShortCommit}}
+  - env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/gitpod-io/leeway/pkg/leeway.Version={{.Version}}-{{.ShortCommit}}
 
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    386: i386
-    amd64: x86_64
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

>  ⨯ release failed after 1m51s               error=failed to build for linux_386: exit status 1: # github.com/opencontainers/runc/libcontainer/specconv
> Error: ../../../go/pkg/mod/github.com/opencontainers/runc@v1.2.0/libcontainer/specconv/spec_linux.go:1015:33: undefined: userns.GetUserNamespaceMappings
> Error: ../../../go/pkg/mod/github.com/opencontainers/runc@v1.2.0/libcontainer/specconv/spec_linux.go:1031:15: undefined: userns.IsSameMapping
> Error: ../../../go/pkg/mod/github.com/opencontainers/runc@v1.2.0/libcontainer/specconv/spec_linux.go:1032:13: undefined: userns.IsSameMapping
