### PR TITLE
Update goreleaser configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,6 @@ jobs:
         with:
           distribution: goreleaser
           version: v2.3.2
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 rice-box.go
 coverage.out
 .idea
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,10 @@ builds:
       - darwin
     ldflags:
       - -s -w -X github.com/gitpod-io/leeway/pkg/leeway.Version={{.Version}}-{{.ShortCommit}}
-
+    goarch:
+      - amd64
+      - arm64
+ 
 archives:
   - format: tar.gz
     name_template: >-

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,21 +1,27 @@
+version: 2
+
 before:
   hooks:
     - go generate ./...
+
 builds:
   - env:
       - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
     ldflags:
       - -s -w -X github.com/gitpod-io/leeway/pkg/leeway.Version={{.Version}}-{{.ShortCommit}}
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      amd64: x86_64
-checksum:
-  name_template: "checksums.txt"
-snapshot:
-  name_template: "{{ .Tag }}-next"
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
 changelog:
   sort: asc
   filters:

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/in-toto/in-toto-golang v0.3.3
 	github.com/karrick/godirwalk v1.17.0
 	github.com/minio/highwayhash v1.0.2
-	github.com/opencontainers/runc v1.2.0
-	github.com/opencontainers/runtime-spec v1.2.0
+	github.com/opencontainers/runc v1.1.10
+	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/segmentio/textio v1.2.0
 	github.com/sirupsen/logrus v1.9.3
@@ -59,7 +59,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.1 // indirect
-	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/moby/sys/mountinfo v0.7.1 h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g=
 github.com/moby/sys/mountinfo v0.7.1/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
-github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
-github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -132,12 +130,12 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
-github.com/opencontainers/runc v1.2.0 h1:qke7ZVCmJcKrJVY2iHJVC+0kql9uYdkusOPsQOOeBw4=
-github.com/opencontainers/runc v1.2.0/go.mod h1:/PXzF0h531HTMsYQnmxXkBD7YaGShm/2zcRB79dksUc=
-github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
-github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
-github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
+github.com/opencontainers/runc v1.1.10 h1:EaL5WeO9lv9wmS6SASjszOeQdSctvpbu0DdBQBizE40=
+github.com/opencontainers/runc v1.1.10/go.mod h1:+/R6+KmDlh+hOO8NkjmgkG9Qzvypzk0yXxAPYYR65+M=
+github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
+github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
+github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/pierrec/lz4/v4 v4.0.3/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Description

- Rollback github.com/opencontainers/runc to v1.1.10 (any version after that throws compilation errors).
- Ensure goreleaser build works.

```
❯ GITHUB_TOKEN=0 /usr/local/bin/goreleaser --verbose release --clean --config .goreleaser.yaml --snapshot
  • verbose output enabled
  • using configuration                              path=.goreleaser.yaml
  • parallelism: 12
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
    • using token from  $GITHUB_TOKEN
    • token type: github
  • getting and validating git state
    • git command result                             args=[-c log.showSignature=false rev-parse --is-inside-work-tree] stdout=true stderr=
    • git command result                             args=[-c log.showSignature=false rev-parse --is-inside-work-tree] stdout=true stderr=
    • git command result                             args=[-c log.showSignature=false rev-parse --abbrev-ref HEAD --quiet] stdout=aledbf/goreleaser-fix stderr=
    • git command result                             args=[-c log.showSignature=false show --format=%h HEAD --quiet] stdout=a89e80b stderr=
    • git command result                             args=[-c log.showSignature=false show --format=%H HEAD --quiet] stdout=a89e80b425a9f199d4187f1445f8bfe22d7e3842 stderr=
    • git command result                             args=[-c log.showSignature=false rev-list --max-parents=0 HEAD] stdout=dccfcf55cee5b90c45188ed154479c10b8362fcf stderr=
    • git command result                             args=[-c log.showSignature=false show --format='%ct' HEAD --quiet] stdout='1730226169' stderr=
    • git command result                             args=[-c log.showSignature=false describe --always --dirty --tags] stdout=v0.8.9-2-ga89e80b-dirty stderr=
    • git command result                             args=[-c log.showSignature=false ls-remote --get-url] stdout=https://github.com/aledbf/leeway stderr=
    • git command result                             args=[-c log.showSignature=false tag --points-at HEAD --sort -version:refname] stdout= stderr=
    • git command result                             args=[-c log.showSignature=false describe --tags --abbrev=0 HEAD] stdout=v0.8.9 stderr=
    • git command result                             args=[-c log.showSignature=false tag -l --format='%(contents:subject)' v0.8.9] stdout='Update go dependencies (#192)' stderr=
    • git command result                             args=[-c log.showSignature=false tag -l --format='%(contents)' v0.8.9] stdout='Update go dependencies (#192)

' stderr=
    • git command result                             args=[-c log.showSignature=false tag -l --format='%(contents:body)' v0.8.9] stdout='' stderr=
    • git command result                             args=[-c log.showSignature=false describe --tags --abbrev=0 tags/v0.8.9^] stdout=v0.8.8 stderr=
    • git command result                             args=[-c log.showSignature=false rev-list -n1 v0.8.8] stdout=64d1c6257769a0bd2c1eda352e4f39899a6ea619 stderr=
    • git command result                             args=[-c log.showSignature=false tag --points-at 64d1c6257769a0bd2c1eda352e4f39899a6ea619 --sort -version:refname] stdout=v0.8.8 stderr=
    • git command result                             args=[-c log.showSignature=false status --porcelain] stdout=M .goreleaser.yaml
 M go.mod
 M go.sum stderr=
    • git state                                      commit=a89e80b425a9f199d4187f1445f8bfe22d7e3842 branch=aledbf/goreleaser-fix current_tag=v0.8.9 previous_tag=v0.8.8 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • git command result                             args=[-c log.showSignature=false rev-parse --is-inside-work-tree] stdout=true stderr=
    • git command result                             args=[-c log.showSignature=false ls-remote --get-url] stdout=https://github.com/aledbf/leeway stderr=
    • got git url                                    rawurl=https://github.com/aledbf/leeway
    • parsed url                                     owner=aledbf name=leeway
    • pre-release for tag v0.8.9 set to false
    • git command result                             args=[-c log.showSignature=false rev-parse --is-inside-work-tree] stdout=true stderr=
    • git command result                             args=[-c log.showSignature=false ls-remote --get-url] stdout=https://github.com/aledbf/leeway stderr=
    • got git url                                    rawurl=https://github.com/aledbf/leeway
    • parsed url                                     owner=aledbf name=leeway
    • git command result                             args=[-c log.showSignature=false config gpg.program] stdout= stderr=
    • git command result                             args=[-c log.showSignature=false config gpg.program] stdout= stderr=
  • skipped partial
  • snapshotting
    • building snapshot...                           version=0.8.9-SNAPSHOT-a89e80b
  • running before hooks
    • running                                        hook=go generate ./...
    • running                                        cmd=[go generate ./...] dir=
  • ensuring distribution directory
    • dist doesn't exist, creating empty directory
  • setting up metadata
  • writing release metadata
    • writing                                        path=dist/metadata.json
    • added new artifact                             name=metadata.json type=Metadata path=dist/metadata.json
  • loading go mod information
  • build prerequisites
  • skipped checking go.mod
  • skipped proxying go module
  • writing effective configuration                  path=dist/config.yaml
  • building binaries
    • building                                       build={leeway [linux darwin] [amd64 arm64] [6] [hardfloat] [v1] [linux_amd64_v1 linux_arm64 darwin_amd64_v1 darwin_arm64] [] . . leeway {[] []} go   go build  false   { [-s -w -X github.com/gitpod-io/leeway/pkg/leeway.Version={{.Version}}-{{.ShortCommit}}] [] [] [] [] [CGO_ENABLED=0]} []}
    • building                                       binary=dist/leeway_linux_amd64_v1/leeway
    • building                                       binary=dist/leeway_darwin_arm64/leeway
    • building                                       binary=dist/leeway_darwin_amd64_v1/leeway
    • building                                       binary=dist/leeway_linux_arm64/leeway
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • running
    • running
    • running
    • running
    • added new artifact                             name=leeway type=Binary path=dist/leeway_linux_amd64_v1/leeway
    • added new artifact                             name=leeway type=Binary path=dist/leeway_linux_arm64/leeway
    • added new artifact                             name=leeway type=Binary path=dist/leeway_darwin_amd64_v1/leeway
    • added new artifact                             name=leeway type=Binary path=dist/leeway_darwin_arm64/leeway
  • skipped universal binaries
  • skipped signing binaries
  • skipped sign & notarize macOS binaries
  • skipped upx
  • skipped generating changelog
  • archives
    • group darwinamd64v1 has 1 binaries
    • group darwinarm64 has 1 binaries
    • group linuxamd64v1 has 1 binaries
    • group linuxarm64 has 1 binaries
    • creating                                       archive=dist/leeway_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/leeway_Darwin_arm64.tar.gz
    • creating                                       archive=dist/leeway_Linux_x86_64.tar.gz
    • creating                                       archive=dist/leeway_Linux_arm64.tar.gz
    • adding file: LICENSE as LICENSE
    • adding file: LICENSE as LICENSE
    • adding file: LICENSE as LICENSE
    • adding file: LICENSE as LICENSE
    • adding file: README.md as README.md
    • adding file: README.md as README.md
    • adding file: README.md as README.md
    • adding file: README.md as README.md
    • adding file: dist/leeway_linux_arm64/leeway as leeway
    • adding file: dist/leeway_darwin_amd64_v1/leeway as leeway
    • adding file: dist/leeway_darwin_arm64/leeway as leeway
    • adding file: dist/leeway_linux_amd64_v1/leeway as leeway
    • added new artifact                             name=leeway_Darwin_arm64.tar.gz type=Archive path=dist/leeway_Darwin_arm64.tar.gz
    • added new artifact                             name=leeway_Linux_arm64.tar.gz type=Archive path=dist/leeway_Linux_arm64.tar.gz
    • added new artifact                             name=leeway_Darwin_x86_64.tar.gz type=Archive path=dist/leeway_Darwin_x86_64.tar.gz
    • added new artifact                             name=leeway_Linux_x86_64.tar.gz type=Archive path=dist/leeway_Linux_x86_64.tar.gz
  • skipped creating source archive
  • skipped linux packages
  • skipped snapcraft packages
  • skipped cataloging artifacts
  • calculating checksums
    • checksumming                                   file=leeway_Linux_x86_64.tar.gz
    • calculating checksum for dist/leeway_Linux_x86_64.tar.gz
    • checksumming                                   file=leeway_Linux_arm64.tar.gz
    • calculating checksum for dist/leeway_Linux_arm64.tar.gz
    • checksumming                                   file=leeway_Darwin_arm64.tar.gz
    • calculating checksum for dist/leeway_Darwin_arm64.tar.gz
    • checksumming                                   file=leeway_Darwin_x86_64.tar.gz
    • calculating checksum for dist/leeway_Darwin_x86_64.tar.gz
    • added new artifact                             name=leeway_0.8.9-SNAPSHOT-a89e80b_checksums.txt type=Checksum path=dist/leeway_0.8.9-SNAPSHOT-a89e80b_checksums.txt
  • skipped signing artifacts
  • skipped arch user repositories
  • skipped nixpkgs
  • skipped winget
  • skipped homebrew tap formula
  • skipped krew plugin manifest
  • skipped scoop manifests
  • skipped chocolatey packages
  • skipped size reports
  • skipped docker images
  • skipped ko
  • skipped publishing
  • writing artifacts metadata
    • writing                                        path=dist/artifacts.json
  • skipped announcing
  • release succeeded after 6s
  • thanks for using goreleaser!
```