### PR TITLE
Build dependencies of cached packages

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -621,8 +621,8 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 		return err
 	}
 
-	// Do this after building dependencies, to ensure all transitive dependencies are built
-	// even if the package itself is already built.
+	// Return early if the package is already built. We're explicitly performing this check after having built all the dependencies.
+	//  Previously we had it before, but that resulted in failed builds as there's no guarantee that the cache will contain transitive dependencies; in our case they were sometimes evicted from the cache due to S3 lifecycle rules
 	_, alreadyBuilt := buildctx.LocalCache.Location(p)
 	if p.Ephemeral {
 		// ephemeral packages always require a rebuild

--- a/pkg/leeway/version.go
+++ b/pkg/leeway/version.go
@@ -1,4 +1,4 @@
 package leeway
 
 // Version is the version of this leeway build
-var Version string = "unkown"
+var Version string = "unknown"

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -230,7 +230,13 @@ func loadWorkspace(ctx context.Context, path string, args Arguments, variant str
 		if err != nil {
 			return Workspace{}, err
 		}
-		ignores = strings.Split(string(fc), "\n")
+		split := strings.Split(string(fc), "\n")
+		for _, s := range split {
+			if s == "" {
+				continue
+			}
+			ignores = append(ignores, s)
+		}
 	}
 	otherWS, err := doublestar.Glob(workspace.Origin, "**/WORKSPACE.yaml", workspace.ShouldIgnoreSource)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes build failure if the dependency of a cached package (no longer) exists in the cache. Now, also checks and builds if needed the dependencies of packages that are already built (in cache).

Drive-by fixes:
- `unkown` -> `unknown`
- ignore empty lines in `.leewayignore`. An empty line would otherwise match every file path and ignore everything

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C06C23ZTFL6/p1733906120191529

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
