### PR TITLE
Improve build cache asset handling

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -166,6 +166,12 @@ func addBuildFlags(cmd *cobra.Command) {
 		cacheDefault = "remote"
 	}
 
+	// Never use all CPUs, leave one free for other processes
+	cpus := runtime.NumCPU()
+	if cpus > 2 {
+		cpus--
+	}
+
 	cmd.Flags().StringP("cache", "c", cacheDefault, "Configures the caching behaviour: none=no caching, local=local caching only, remote-pull=download from remote but never upload, remote-push=push to remote cache only but don't download, remote=use all configured caches")
 	cmd.Flags().Bool("dry-run", false, "Don't actually build but stop after showing what would need to be built")
 	cmd.Flags().String("dump-plan", "", "Writes the build plan as JSON to a file. Use \"-\" to write the build plan to stderr.")
@@ -173,7 +179,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("dont-test", false, "Disable all package-level tests (defaults to false)")
 	cmd.Flags().Bool("dont-compress", false, "Disable compression of build artifacts (defaults to false)")
 	cmd.Flags().Bool("jailed-execution", false, "Run all build commands using runc (defaults to false)")
-	cmd.Flags().UintP("max-concurrent-tasks", "j", uint(runtime.NumCPU()), "Limit the number of max concurrent build tasks - set to 0 to disable the limit")
+	cmd.Flags().UintP("max-concurrent-tasks", "j", uint(cpus), "Limit the number of max concurrent build tasks - set to 0 to disable the limit")
 	cmd.Flags().String("coverage-output-path", "", "Output path where test coverage file will be copied after running tests")
 	cmd.Flags().StringToString("docker-build-options", nil, "Options passed to all 'docker build' commands")
 	cmd.Flags().String("report", "", "Generate a HTML report after the build has finished. (e.g. --report myreport.html)")

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -446,15 +446,7 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 		return err
 	}
 
-	pkgsInRemoteCacheMap := make(map[*Package]struct{})
-	// convert pkgsInRemoteCache to map[*Package]struct{}
-	for p := range pkgsInRemoteCache {
-		for _, pkg := range allpkg {
-			if pkg.FullName() == p.FullName() {
-				pkgsInRemoteCacheMap[pkg] = struct{}{}
-			}
-		}
-	}
+	pkgsInRemoteCacheMap := toPackageMap(pkgsInRemoteCache)
 
 	pkgsWillBeDownloaded := make(map[*Package]struct{})
 	pkg.packagesToDownload(pkgsInLocalCache, pkgsInRemoteCacheMap, pkgsWillBeDownloaded)

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -864,14 +864,6 @@ func (p *Package) packagesToDownload(inLocalCache map[*Package]struct{}, inRemot
 	if existsInRemoteCache {
 		// If the package is in the remote cache then we want to download it
 		toDownload[p] = struct{}{}
-
-		// If we don't download the package is going to be built (missing in local cache)
-		// // For Generic and Docker packages we can short-circuit here.
-		// // For Yarn and Go we can not, see comment below for details.
-		// switch p.Type {
-		// case GenericPackage, DockerPackage:
-		// 	return
-		// }
 	}
 
 	var deps []*Package

--- a/pkg/leeway/cache/remote/s3.go
+++ b/pkg/leeway/cache/remote/s3.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -189,75 +191,132 @@ func (s *S3Cache) ExistingPackages(ctx context.Context, pkgs []cache.Package) (m
 	return result, nil
 }
 
+// withRetry attempts an operation with retries and exponential backoff
+func withRetry(maxRetries int, operation func() error) error {
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = operation()
+		if err == nil {
+			return nil
+		}
+
+		// Don't retry if the object doesn't exist
+		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+			return err
+		}
+
+		log.WithError(err).WithField("retry", i+1).Debug("Operation failed, retrying...")
+		// Exponential backoff with jitter
+		sleepTime := time.Duration(50*(i+1)*int(1+rand.Intn(10))) * time.Millisecond
+		time.Sleep(sleepTime)
+	}
+	return fmt.Errorf("operation failed after %d retries: %w", maxRetries, err)
+}
+
 // Download implements RemoteCache
 func (s *S3Cache) Download(ctx context.Context, dst cache.LocalCache, pkgs []cache.Package) error {
+	var multiErr []error
+
 	err := s.processPackages(ctx, pkgs, func(ctx context.Context, p cache.Package) error {
 		version, err := p.Version()
 		if err != nil {
-			return fmt.Errorf("failed to get version for package %s: %w", p.FullName(), err)
+			log.WithError(err).WithField("package", p.FullName()).Warn("Failed to get version for package, skipping")
+			return nil // Skip but don't fail everything
 		}
 
 		localPath, exists := dst.Location(p)
-		if !exists || localPath == "" {
-			return fmt.Errorf("failed to get local path for package %s", p.FullName())
+		if exists {
+			log.WithField("package", p.FullName()).Debug("Package already exists in local cache, skipping download")
+			return nil
 		}
 
-		// Try downloading .tar.gz first
+		if localPath == "" {
+			log.WithField("package", p.FullName()).Warn("Failed to get local path for package, skipping download")
+			return nil // Skip but don't fail everything
+		}
+
+		// Ensure parent directory exists
+		if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"package": p.FullName(),
+				"dir":     filepath.Dir(localPath),
+			}).Warn("Failed to create directory for package, skipping download")
+			return nil
+		}
+
+		// Try downloading .tar.gz first with retry
 		gzKey := fmt.Sprintf("%s.tar.gz", version)
-		_, err = s.storage.GetObject(ctx, gzKey, localPath)
-		if err == nil {
+		gzErr := withRetry(3, func() error {
+			_, err := s.storage.GetObject(ctx, gzKey, localPath)
+			return err
+		})
+
+		if gzErr == nil {
 			log.WithFields(log.Fields{
 				"package": p.FullName(),
 				"key":     gzKey,
-			}).Debug("successfully downloaded package from remote cache (.tar.gz)")
+				"path":    localPath,
+			}).Debug("Successfully downloaded package from remote cache (.tar.gz)")
 			return nil
 		}
 
 		// Check if this is a "not found" error
-		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+		if strings.Contains(gzErr.Error(), "NotFound") || strings.Contains(gzErr.Error(), "404") {
 			log.WithFields(log.Fields{
 				"package": p.FullName(),
 				"key":     gzKey,
-			}).Debug("package not found in remote cache (.tar.gz), trying .tar")
+			}).Debug("Package not found in remote cache (.tar.gz), trying .tar")
 		} else {
 			log.WithFields(log.Fields{
 				"package": p.FullName(),
 				"key":     gzKey,
-				"error":   err,
-			}).Debug("failed to download .tar.gz from remote cache, trying .tar")
+				"error":   gzErr,
+			}).Debug("Failed to download .tar.gz from remote cache, trying .tar")
 		}
 
-		// Try .tar if .tar.gz fails
+		// Try .tar if .tar.gz fails, also with retry
 		tarKey := fmt.Sprintf("%s.tar", version)
-		_, err = s.storage.GetObject(ctx, tarKey, localPath)
-		if err != nil {
+		tarErr := withRetry(3, func() error {
+			_, err := s.storage.GetObject(ctx, tarKey, localPath)
+			return err
+		})
+
+		if tarErr != nil {
 			// Check if this is a "not found" error
-			if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+			if strings.Contains(tarErr.Error(), "NotFound") || strings.Contains(tarErr.Error(), "404") {
 				log.WithFields(log.Fields{
 					"package": p.FullName(),
 					"key":     tarKey,
-				}).Debug("package not found in remote cache (.tar), will build locally")
+				}).Debug("Package not found in remote cache (.tar), will build locally")
 				return nil // Not an error, just not found
 			}
 
 			log.WithFields(log.Fields{
 				"package": p.FullName(),
 				"key":     tarKey,
-				"error":   err,
-			}).Debug("failed to download package from remote cache, will build locally")
+				"error":   tarErr,
+			}).Debug("Failed to download package from remote cache, will build locally")
 			return nil // Continue with local build
 		}
 
 		log.WithFields(log.Fields{
 			"package": p.FullName(),
 			"key":     tarKey,
-		}).Debug("successfully downloaded package from remote cache (.tar)")
+			"path":    localPath,
+		}).Debug("Successfully downloaded package from remote cache (.tar)")
 		return nil
 	})
 
 	if err != nil {
-		log.WithError(err).Warn("errors occurred during download from remote cache")
-		// Continue with local builds for packages that couldn't be downloaded
+		log.WithError(err).Warn("Errors occurred during download from remote cache, continuing with local builds")
+		multiErr = append(multiErr, err)
+	}
+
+	// Even if there were errors with some packages, don't fail the entire build
+	// Just log warnings and continue with local builds for those packages
+	if len(multiErr) > 0 {
+		log.WithField("errors", len(multiErr)).Warn("Some packages could not be downloaded, falling back to local builds")
+		// Return nil instead of the error to allow the build to continue with local builds
 		return nil
 	}
 
@@ -333,6 +392,31 @@ func (s *S3Storage) HasObject(ctx context.Context, key string) (bool, error) {
 	return true, nil
 }
 
+// ValidateObject checks if a downloaded object exists and has a valid size
+func (s *S3Storage) ValidateObject(ctx context.Context, key, localPath string) error {
+	// Check if the file exists
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return fmt.Errorf("downloaded file not found: %w", err)
+	}
+
+	// If the file size is 0, the download likely failed
+	if info.Size() == 0 {
+		return fmt.Errorf("downloaded file is empty")
+	}
+
+	// Validate the checksum if available
+	// We don't have access to the response headers here directly,
+	// but the AWS SDK should have already validated the checksum
+	// if ChecksumMode was enabled in the request
+	log.WithFields(log.Fields{
+		"path": localPath,
+		"size": info.Size(),
+	}).Debug("Validated downloaded file")
+
+	return nil
+}
+
 // GetObject implements ObjectStorage
 func (s *S3Storage) GetObject(ctx context.Context, key string, dest string) (int64, error) {
 	downloader := manager.NewDownloader(s.client, func(d *manager.Downloader) {
@@ -350,10 +434,13 @@ func (s *S3Storage) GetObject(ctx context.Context, key string, dest string) (int
 	}
 	defer file.Close()
 
-	n, err := downloader.Download(ctx, file, &s3.GetObjectInput{
-		Bucket: aws.String(s.bucketName),
-		Key:    aws.String(key),
-	})
+	input := &s3.GetObjectInput{
+		Bucket:       aws.String(s.bucketName),
+		Key:          aws.String(key),
+		ChecksumMode: types.ChecksumModeEnabled,
+	}
+
+	n, err := downloader.Download(ctx, file, input)
 
 	if err != nil {
 		// Remove the partially downloaded file if there was an error
@@ -373,6 +460,13 @@ func (s *S3Storage) GetObject(ctx context.Context, key string, dest string) (int
 		return 0, fmt.Errorf("failed to download object: %w", err)
 	}
 
+	// Validate the downloaded file
+	if err := s.ValidateObject(ctx, key, dest); err != nil {
+		// Remove the invalid file
+		os.Remove(dest)
+		return 0, fmt.Errorf("downloaded object validation failed: %w", err)
+	}
+
 	return n, nil
 }
 
@@ -388,11 +482,14 @@ func (s *S3Storage) UploadObject(ctx context.Context, key string, src string) er
 		u.PartSize = defaultS3PartSize
 	})
 
-	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(s.bucketName),
-		Key:    aws.String(key),
-		Body:   file,
-	})
+	input := &s3.PutObjectInput{
+		Bucket:            aws.String(s.bucketName),
+		Key:               aws.String(key),
+		Body:              file,
+		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+	}
+
+	_, err = uploader.Upload(ctx, input)
 	if err != nil {
 		return fmt.Errorf("failed to upload object: %w", err)
 	}

--- a/pkg/leeway/cache/remote/s3_download_test.go
+++ b/pkg/leeway/cache/remote/s3_download_test.go
@@ -1,0 +1,215 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/leeway/pkg/leeway/cache"
+	"github.com/gitpod-io/leeway/pkg/leeway/cache/local"
+	"github.com/google/go-cmp/cmp"
+)
+
+// s3TestPackage for testing S3 download functionality
+type s3TestPackage struct {
+	versionStr string
+	fullName   string
+	versionErr error
+}
+
+func (m s3TestPackage) Version() (string, error) {
+	return m.versionStr, m.versionErr
+}
+
+func (m s3TestPackage) FullName() string {
+	return m.fullName
+}
+
+// mockS3Storage implements a simple ObjectStorage for testing
+type mockS3Storage struct {
+	objects       map[string][]byte
+	failDownload  bool
+	downloadDelay time.Duration
+}
+
+func (m *mockS3Storage) HasObject(ctx context.Context, key string) (bool, error) {
+	_, exists := m.objects[key]
+	return exists, nil
+}
+
+func (m *mockS3Storage) GetObject(ctx context.Context, key string, dest string) (int64, error) {
+	if m.failDownload {
+		return 0, errors.New("simulated download failure")
+	}
+
+	if m.downloadDelay > 0 {
+		time.Sleep(m.downloadDelay)
+	}
+
+	data, exists := m.objects[key]
+	if !exists {
+		return 0, errors.New("NotFound: object does not exist")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return 0, err
+	}
+
+	if err := os.WriteFile(dest, data, 0644); err != nil {
+		return 0, err
+	}
+
+	return int64(len(data)), nil
+}
+
+func (m *mockS3Storage) UploadObject(ctx context.Context, key string, src string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	m.objects[key] = data
+	return nil
+}
+
+func (m *mockS3Storage) ListObjects(ctx context.Context, prefix string) ([]string, error) {
+	var result []string
+	for key := range m.objects {
+		if len(prefix) == 0 || key[:len(prefix)] == prefix {
+			result = append(result, key)
+		}
+	}
+	return result, nil
+}
+
+func TestS3CacheDownload(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	localCache, err := local.NewFilesystemCache(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create local cache: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		packages       []cache.Package
+		mockObjects    map[string][]byte
+		failDownload   bool
+		downloadDelay  time.Duration
+		wantDownloaded map[string]bool
+		wantErrorCount int
+	}{
+		{
+			name: "successful download",
+			packages: []cache.Package{
+				s3TestPackage{versionStr: "v1", fullName: "pkg1"},
+			},
+			mockObjects: map[string][]byte{
+				"v1.tar.gz": []byte("test data"),
+			},
+			wantDownloaded: map[string]bool{
+				"v1.tar.gz": true,
+			},
+		},
+		{
+			name: "fallback to tar",
+			packages: []cache.Package{
+				s3TestPackage{versionStr: "v2", fullName: "pkg2"},
+			},
+			mockObjects: map[string][]byte{
+				"v2.tar": []byte("test data for tar"),
+			},
+			wantDownloaded: map[string]bool{
+				"v2.tar": true,
+			},
+		},
+		{
+			name: "package not found",
+			packages: []cache.Package{
+				s3TestPackage{versionStr: "v3", fullName: "pkg3"},
+			},
+			mockObjects:    map[string][]byte{},
+			wantDownloaded: map[string]bool{},
+		},
+		{
+			name: "download failure with retry success",
+			packages: []cache.Package{
+				s3TestPackage{versionStr: "v4", fullName: "pkg4"},
+			},
+			mockObjects: map[string][]byte{
+				"v4.tar.gz": []byte("test data"),
+			},
+			downloadDelay: 10 * time.Millisecond, // Simulate network latency
+			wantDownloaded: map[string]bool{
+				"v4.tar.gz": true,
+			},
+		},
+		{
+			name: "package version error",
+			packages: []cache.Package{
+				s3TestPackage{versionStr: "", fullName: "pkg5", versionErr: errors.New("version error")},
+			},
+			mockObjects:    map[string][]byte{},
+			wantDownloaded: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up the temp directory
+			files, _ := filepath.Glob(filepath.Join(tmpDir, "*"))
+			for _, f := range files {
+				os.Remove(f)
+			}
+
+			mockStorage := &mockS3Storage{
+				objects:       tt.mockObjects,
+				failDownload:  tt.failDownload,
+				downloadDelay: tt.downloadDelay,
+			}
+
+			s3Cache := &S3Cache{
+				storage:     mockStorage,
+				workerCount: 1,
+			}
+
+			err := s3Cache.Download(context.Background(), localCache, tt.packages)
+
+			// We always return nil from Download now to continue with local builds
+			if err != nil {
+				t.Errorf("expected no error but got %v", err)
+			}
+
+			// Check if expected files were downloaded
+			for pkg, expectedDownload := range tt.wantDownloaded {
+				// We need to look for the file based on the version as that's how the local cache stores it
+				// Extract the version from the package name (v1, v2, etc.)
+				version := strings.TrimSuffix(strings.TrimSuffix(pkg, ".tar.gz"), ".tar")
+				path := filepath.Join(tmpDir, pkg)
+				_, err := os.Stat(path)
+				fileExists := err == nil
+
+				if expectedDownload && !fileExists {
+					// Check if any file with the version prefix exists
+					matches, _ := filepath.Glob(filepath.Join(tmpDir, version+"*"))
+					if len(matches) == 0 {
+						t.Errorf("expected a file for package %s to be downloaded but none was found", pkg)
+					}
+				} else if !expectedDownload && fileExists {
+					t.Errorf("didn't expect file %s to be downloaded but it was", pkg)
+				}
+
+				if fileExists {
+					data, _ := os.ReadFile(path)
+					if !cmp.Equal(data, mockStorage.objects[pkg]) {
+						t.Errorf("file contents mismatch for %s", pkg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/leeway/scripts.go
+++ b/pkg/leeway/scripts.go
@@ -209,8 +209,19 @@ func (p *Script) synthesizePackagesWorkdir(buildCtx *buildContext) (path string,
 			return
 		}
 
+		var untarCmd []string
+		untarCmd, err = BuildUnTarCommand(
+			WithInputFile(br),
+			WithTargetDir(loc),
+			WithAutoDetectCompression(true),
+		)
+		if err != nil {
+			err = xerrors.Errorf("cannot build untar command for %s: %w", dep.FullName(), err)
+			return
+		}
+
 		var out []byte
-		cmd := exec.Command("tar", "--sparse", "-xzf", br)
+		cmd := exec.Command(untarCmd[0], untarCmd[1:]...)
 		cmd.Dir = loc
 		out, err = cmd.CombinedOutput()
 		if err != nil {

--- a/pkg/leeway/scripts.go
+++ b/pkg/leeway/scripts.go
@@ -210,7 +210,7 @@ func (p *Script) synthesizePackagesWorkdir(buildCtx *buildContext) (path string,
 		}
 
 		var out []byte
-		cmd := exec.Command("tar", getTarArgs("-xzf", br)...)
+		cmd := exec.Command("tar", "--sparse", "-xzf", br)
 		cmd.Dir = loc
 		out, err = cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
## Description

In leeway, some tasks of a generic or docker type do not download the generated assets during the build. This means they will not exist in the local cache and will be built on every build run. This results in unnecessary build time for specific CI jobs and bypasses the use of the cache.

```
🌎  cached remotely (ignored)     runner/linux:raw-app                           (version 18f83f9e73331afe67b8f8eb10e5bc5570aa62c7)
🌎  cached remotely (ignored)     runner/shared/openssh:docker                   (version 8e42cdd4b76079dafce8eb748bda6543c7a3273a)
🌎  cached remotely (ignored)     runner/shared/openssh:runner                   (version 5b4728c43b439b641fe3fc167488cd842a435131)
📥  cached remotely (downloaded)  dev/oidc:lib                                   (version 4c6dab91df7df089794ac37ee23e95361953cec6)
📥  cached remotely (downloaded)  frontend/desktop:app                           (version 314a4f7bea7f9cd4ae7b5020f41f06a21c77fae1)
```
