### PR TITLE
Log build phase durations

### DIFF
--- a/pkg/leeway/reporter_test.go
+++ b/pkg/leeway/reporter_test.go
@@ -1,0 +1,109 @@
+package leeway
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConsoleReporter(t *testing.T) {
+	t.Parallel()
+
+	type Expectation struct {
+		Output string
+	}
+
+	start := time.Now()
+	pkg := &Package{
+		C: &Component{
+			Name: "test",
+		},
+		PackageInternal: PackageInternal{
+			Name: "test",
+		},
+	}
+
+	tests := []struct {
+		Name     string
+		Reporter Reporter
+		Func     func(t *testing.T, r *ConsoleReporter)
+		Expect   Expectation
+	}{
+		{
+			Name: "all phases",
+			Func: func(t *testing.T, r *ConsoleReporter) {
+				r.PackageBuildStarted(pkg)
+
+				r.now = func() time.Time {
+					return start.Add(5 * time.Second)
+				}
+				r.PackageBuildFinished(pkg, &PackageBuildReport{
+					Phases: []PackageBuildPhase{
+						PackageBuildPhasePrep,
+						PackageBuildPhasePull,
+						PackageBuildPhaseLint,
+						PackageBuildPhaseTest,
+						PackageBuildPhaseBuild},
+					phaseEnter: map[PackageBuildPhase]time.Time{
+						PackageBuildPhasePrep:  start,
+						PackageBuildPhasePull:  start.Add(time.Second),
+						PackageBuildPhaseBuild: start.Add(2 * time.Second),
+						PackageBuildPhaseTest:  start.Add(3 * time.Second),
+						PackageBuildPhaseLint:  start.Add(4 * time.Second),
+					},
+					phaseDone: map[PackageBuildPhase]time.Time{
+						PackageBuildPhasePrep:  start.Add(time.Second),
+						PackageBuildPhasePull:  start.Add(2 * time.Second),
+						PackageBuildPhaseBuild: start.Add(3 * time.Second),
+						PackageBuildPhaseTest:  start.Add(4 * time.Second),
+						PackageBuildPhaseLint:  start.Add(5 * time.Second),
+					},
+				})
+			},
+			Expect: Expectation{
+				Output: `[test:test] build started (version unknown)
+[test:test] package build succeded (5.00s) [prep: 1.0s | pull: 1.0s | lint: 1.0s | test: 1.0s | build: 1.0s]
+`,
+			},
+		},
+		{
+			Name: "no phases",
+			Func: func(t *testing.T, r *ConsoleReporter) {
+				r.PackageBuildStarted(pkg)
+				r.PackageBuildFinished(pkg, &PackageBuildReport{
+					Phases: []PackageBuildPhase{},
+				})
+			},
+			Expect: Expectation{
+				Output: `[test:test] build started (version unknown)
+[test:test] package build succeded (0.00s)
+`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			var (
+				act Expectation
+				buf bytes.Buffer
+			)
+
+			reporter := NewConsoleReporter()
+			reporter.out = &buf
+			reporter.now = func() time.Time {
+				return start
+			}
+
+			test.Func(t, reporter)
+			act.Output = buf.String()
+
+			if diff := cmp.Diff(test.Expect.Output, act.Output); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Log durations of individual phases, to better understand where time is spent during the build

Specifically trying to see how much time is spent on running golangci-lint for large components

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
