### PR TITLE
Fix build failure reported as success

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -631,7 +631,7 @@ func (p *Package) buildDependencies(buildctx *buildContext) error {
 	return g.Wait()
 }
 
-func (p *Package) build(buildctx *buildContext) error {
+func (p *Package) build(buildctx *buildContext) (err error) {
 	// Try to obtain lock for building this package
 	doBuild := buildctx.ObtainBuildLock(p)
 	if !doBuild {
@@ -663,7 +663,6 @@ func (p *Package) build(buildctx *buildContext) error {
 	buildctx.Reporter.PackageBuildStarted(p)
 
 	// Ensure we notify reporter when build finishes
-	var err error
 	defer func() {
 		pkgRep.Error = err
 		buildctx.Reporter.PackageBuildFinished(p, pkgRep)

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -241,7 +241,7 @@ func (r *ConsoleReporter) PackageBuildFinished(pkg *Package, rep *PackageBuildRe
 		if rep.TestCoverageAvailable {
 			coverage = color.Sprintf("<fg=yellow>test coverage: %d%%</> <gray>(%d of %d functions have tests)</>\n", rep.TestCoveragePercentage, rep.FunctionsWithTest, rep.FunctionsWithTest+rep.FunctionsWithoutTest)
 		}
-		msg = color.Sprintf("%s<green>package build succeded</> <gray>(%.2fs)%s</>\n", coverage, dur.Seconds(), phaseDurStr)
+		msg = color.Sprintf("%s<green>package build succeeded</> <gray>(%.2fs)%s</>\n", coverage, dur.Seconds(), phaseDurStr)
 	}
 	//nolint:errcheck
 	io.WriteString(out, msg)

--- a/pkg/leeway/reporter_test.go
+++ b/pkg/leeway/reporter_test.go
@@ -2,6 +2,7 @@ package leeway
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestConsoleReporter(t *testing.T) {
 			},
 			Expect: Expectation{
 				Output: `[test:test] build started (version unknown)
-[test:test] package build succeded (5.00s) [prep: 1.0s | pull: 1.0s | lint: 1.0s | test: 1.0s | build: 1.0s]
+[test:test] package build succeeded (5.00s) [prep: 1.0s | pull: 1.0s | lint: 1.0s | test: 1.0s | build: 1.0s]
 `,
 			},
 		},
@@ -78,7 +79,22 @@ func TestConsoleReporter(t *testing.T) {
 			},
 			Expect: Expectation{
 				Output: `[test:test] build started (version unknown)
-[test:test] package build succeded (0.00s)
+[test:test] package build succeeded (0.00s)
+`,
+			},
+		},
+		{
+			Name: "failed build",
+			Func: func(t *testing.T, r *ConsoleReporter) {
+				r.PackageBuildStarted(pkg)
+				r.PackageBuildFinished(pkg, &PackageBuildReport{
+					Error: errors.New("failed"),
+				})
+			},
+			Expect: Expectation{
+				Output: `[test:test] build started (version unknown)
+[test:test] package build failed while preping
+[test:test] Reason: failed
 `,
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

fixes build error not getting set in package build report, logging build as succeeded instead of failed, e.g.:
```
[foo:bar] error Command failed with exit code 1.
time="2025-04-08T15:29:18Z" level=fatal msg="build failed"
[foo:bar] package build succeded (134.56s) [prep: 0.0s | pull: 27.4s | test: 106.5s]
build failed
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
