### PR TITLE
CLC-1361: Ignore ephemeral packages during scanning

### DIFF
--- a/cmd/sbom-export.go
+++ b/cmd/sbom-export.go
@@ -62,9 +62,17 @@ If no package is specified, the workspace's default target is used.`,
 		if withDependencies {
 			// Get all dependencies
 			deps := pkg.GetTransitiveDependencies()
-			log.Infof("Exporting SBOMs for %s and %d dependencies to %s", pkg.FullName(), len(deps), outputDir)
 
-			allpkg = append(allpkg, deps...)
+			// Skip ephemeral packages as they're not meant to be cached
+			for _, p := range deps {
+				if p.Ephemeral {
+					log.Infof("Skipping vulnerability scan for ephemeral package %s\n", p.FullName())
+					continue
+				}
+				allpkg = append(allpkg, p)
+			}
+
+			log.Infof("Exporting SBOMs for %s and %d dependencies to %s", pkg.FullName(), len(allpkg)-1, outputDir)
 		}
 
 		for _, p := range allpkg {

--- a/cmd/sbom-scan.go
+++ b/cmd/sbom-scan.go
@@ -54,7 +54,17 @@ If no package is specified, the workspace's default target is used.`,
 			deps := pkg.GetTransitiveDependencies()
 			log.Infof("Scanning SBOMs for %s and %d dependencies to %s", pkg.FullName(), len(deps), outputDir)
 
-			allpkg = append(allpkg, deps...)
+			// Skip ephemeral packages as they're not meant to be cached
+			var filteredDeps []*leeway.Package
+			for _, p := range deps {
+				if p.Ephemeral {
+					log.Infof("Skipping vulnerability scan for ephemeral package %s\n", p.FullName())
+					continue
+				}
+				filteredDeps = append(filteredDeps, p)
+			}
+
+			allpkg = append(allpkg, filteredDeps...)
 		}
 
 		// Download packages from remote cache when needed

--- a/pkg/leeway/sbom-scan.go
+++ b/pkg/leeway/sbom-scan.go
@@ -80,6 +80,12 @@ func scanAllPackagesForVulnerabilities(buildctx *buildContext, packages []*Packa
 			return xerrors.Errorf(string(errMsg))
 		}
 
+		// Skip ephemeral packages as they're not meant to be cached
+		if p.Ephemeral {
+			buildctx.Reporter.PackageBuildLog(p, false, []byte(fmt.Sprintf("Skipping vulnerability scan for ephemeral package %s\n", p.FullName())))
+			continue
+		}
+
 		location, exists := buildctx.LocalCache.Location(p)
 		if !exists {
 			errMsg := fmt.Appendf(nil, "Package %s not found in local cache, cannot scan for vulnerabilities\n", p.FullName())


### PR DESCRIPTION
This is required to be able to do a scan without building them.
Ignoring those is ok, because they don't contribute build artifacts that need scanning.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [CLC-1361](https://linear.app/gitpod/issue/CLC-1361/leeway-skip-ephemeral-packages-during-sbom-export)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
