### PR TITLE
Make builddir reporting beautiful

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -667,15 +667,6 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 	}
 	pkgRep.phaseEnter[PackageBuildPhasePrep] = time.Now()
 
-	// Notify reporter that package build is starting
-	buildctx.Reporter.PackageBuildStarted(p)
-
-	// Ensure we notify reporter when build finishes
-	defer func() {
-		pkgRep.Error = err
-		buildctx.Reporter.PackageBuildFinished(p, pkgRep)
-	}()
-
 	// Prepare build directory
 	builddir, err := createBuildDir(buildctx, p)
 	if err != nil {
@@ -687,7 +678,14 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 		os.RemoveAll(builddir)
 	}()
 
-	log.WithField("package", p.FullName()).WithField("builddir", builddir).Info("using build directory")
+	// Notify reporter that package build is starting
+	buildctx.Reporter.PackageBuildStarted(p, builddir)
+
+	// Ensure we notify reporter when build finishes
+	defer func() {
+		pkgRep.Error = err
+		buildctx.Reporter.PackageBuildFinished(p, pkgRep)
+	}()
 	if err := prepareDirectory(builddir); err != nil {
 		return err
 	}

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -36,9 +36,9 @@ type Reporter interface {
 	// The root package will also be passed into PackageBuildFinished once it's been built.
 	BuildFinished(pkg *Package, err error)
 
-	// PackageBuildStarted is called when a package build actually gets underway. At this point
+		// PackageBuildStarted is called when a package build actually gets underway. At this point
 	// all transitive dependencies of the package have been built.
-	PackageBuildStarted(pkg *Package)
+	PackageBuildStarted(pkg *Package, builddir string)
 
 	// PackageBuildLog is called during a package build whenever a build command produced some output.
 	PackageBuildLog(pkg *Package, isErr bool, buf []byte)
@@ -188,7 +188,7 @@ func (r *ConsoleReporter) BuildFinished(pkg *Package, err error) {
 }
 
 // PackageBuildStarted is called when a package build actually gets underway.
-func (r *ConsoleReporter) PackageBuildStarted(pkg *Package) {
+func (r *ConsoleReporter) PackageBuildStarted(pkg *Package, builddir string) {
 	out := r.getWriter(pkg)
 
 	version, err := pkg.Version()
@@ -200,7 +200,7 @@ func (r *ConsoleReporter) PackageBuildStarted(pkg *Package) {
 	r.times[pkg.FullName()] = r.now()
 	r.mu.Unlock()
 
-	_, _ = io.WriteString(out, color.Sprintf("<fg=yellow>build started</> <gray>(version %s)</>\n", version))
+	_, _ = io.WriteString(out, color.Sprintf("<fg=yellow>build started</> <gray>(version %s, builddir %s)</>\n", version, builddir))
 }
 
 // PackageBuildLog is called during a package build whenever a build command produced some output.
@@ -403,7 +403,7 @@ func (r *HTMLReporter) BuildFinished(pkg *Package, err error) {
 	r.Report()
 }
 
-func (r *HTMLReporter) PackageBuildStarted(pkg *Package) {
+func (r *HTMLReporter) PackageBuildStarted(pkg *Package, builddir string) {
 	rep := r.getReport(pkg)
 	rep.start = time.Now()
 	rep.status = PackageBuilding
@@ -529,9 +529,9 @@ func (cr CompositeReporter) PackageBuildLog(pkg *Package, isErr bool, buf []byte
 }
 
 // PackageBuildStarted implements Reporter
-func (cr CompositeReporter) PackageBuildStarted(pkg *Package) {
+func (cr CompositeReporter) PackageBuildStarted(pkg *Package, builddir string) {
 	for _, r := range cr {
-		r.PackageBuildStarted(pkg)
+		r.PackageBuildStarted(pkg, builddir)
 	}
 }
 
@@ -552,7 +552,7 @@ func (*NoopReporter) PackageBuildFinished(pkg *Package, rep *PackageBuildReport)
 func (*NoopReporter) PackageBuildLog(pkg *Package, isErr bool, buf []byte) {}
 
 // PackageBuildStarted implements Reporter
-func (*NoopReporter) PackageBuildStarted(pkg *Package) {}
+func (*NoopReporter) PackageBuildStarted(pkg *Package, builddir string) {}
 
 var _ Reporter = ((*NoopReporter)(nil))
 

--- a/pkg/leeway/reporter_test.go
+++ b/pkg/leeway/reporter_test.go
@@ -33,9 +33,9 @@ func TestConsoleReporter(t *testing.T) {
 		Expect   Expectation
 	}{
 		{
-			Name: "all phases",
+						Name: "all phases",
 			Func: func(t *testing.T, r *ConsoleReporter) {
-				r.PackageBuildStarted(pkg)
+				r.PackageBuildStarted(pkg, "/tmp/build")
 
 				r.now = func() time.Time {
 					return start.Add(5 * time.Second)
@@ -64,7 +64,7 @@ func TestConsoleReporter(t *testing.T) {
 				})
 			},
 			Expect: Expectation{
-				Output: `[test:test] build started (version unknown)
+				Output: `[test:test] build started (version unknown, builddir /tmp/build)
 [test:test] package build succeeded (5.00s) [prep: 1.0s | pull: 1.0s | lint: 1.0s | test: 1.0s | build: 1.0s]
 `,
 			},
@@ -72,13 +72,13 @@ func TestConsoleReporter(t *testing.T) {
 		{
 			Name: "no phases",
 			Func: func(t *testing.T, r *ConsoleReporter) {
-				r.PackageBuildStarted(pkg)
+				r.PackageBuildStarted(pkg, "/tmp/build")
 				r.PackageBuildFinished(pkg, &PackageBuildReport{
 					Phases: []PackageBuildPhase{},
 				})
 			},
 			Expect: Expectation{
-				Output: `[test:test] build started (version unknown)
+				Output: `[test:test] build started (version unknown, builddir /tmp/build)
 [test:test] package build succeeded (0.00s)
 `,
 			},
@@ -86,13 +86,13 @@ func TestConsoleReporter(t *testing.T) {
 		{
 			Name: "failed build",
 			Func: func(t *testing.T, r *ConsoleReporter) {
-				r.PackageBuildStarted(pkg)
+				r.PackageBuildStarted(pkg, "/tmp/build")
 				r.PackageBuildFinished(pkg, &PackageBuildReport{
 					Error: errors.New("failed"),
 				})
 			},
 			Expect: Expectation{
-				Output: `[test:test] build started (version unknown)
+				Output: `[test:test] build started (version unknown, builddir /tmp/build)
 [test:test] package build failed while preping
 [test:test] Reason: failed
 `,


### PR DESCRIPTION
## Description
This PR enhances the build reporting functionality by adding the build directory information to the package build reporting. The changes include:

1. Modified the `PackageBuildStarted` method signature in the `Reporter` interface to include the build directory path as a parameter.
2. Moved the reporter notification code in the build process to occur after the build directory is created, allowing it to include the build directory information.
3. Updated the console output to display the build directory path alongside the version information.
4. Updated all implementations of the `Reporter` interface to accommodate the new parameter.
5. Updated tests to reflect these changes.

The main benefit is improved visibility into where each package is being built, which can be helpful for debugging and understanding the build process.

## Related Issue(s)
<!-- No explicit issue number was found in the commit message -->

## How to test
The changes can be tested using the existing automated tests in `reporter_test.go`, which have been updated to verify the new build directory reporting functionality. The tests verify that:

1. The build directory is correctly displayed in the console output
2. The reporter interface correctly handles the new parameter
3. All reporter implementations (Console, HTML, Composite, Noop) properly support the new parameter

Running `go test ./pkg/leeway/... -run TestConsoleReporter` should pass and verify the changes.