### PR TITLE
Install Claude Code & setup key from File Secret

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,5 +9,17 @@ RUN bash -c 'set -euo pipefail && \
     install -m 755 /tmp/leeway /usr/local/bin/ && \
     rm /tmp/leeway.tar.gz /tmp/leeway'
 
+# Install Node.js
+ENV NODE_MAJOR=20
+ADD https://raw.githubusercontent.com/gitpod-io/workspace-images/main/base/install-packages /usr/bin/install-packages
+RUN chmod +x /usr/bin/install-packages
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+    install-packages nodejs && \
+    rm -rf /usr/include/node/openssl/archs/{aix64-gcc-as,BSD-x86,BSD-x86_64,darwin64-arm64-cc,darwin64-x86_64-cc,darwin-i386-cc,linux32-s390x,linux64-loongarch64,linux64-mips64,linux64-riscv64,linux64-s390x,linux-armv4,linux-ppc64le,solaris64-x86_64-gcc,solaris-x86-gcc,VC-WIN32} && \
+    rm -rf /usr/share/doc/nodejs && \
+    rm -rf ./.npm/_cacache
+        
 # Install claude-code globally
 RUN npm i -g @anthropic-ai/claude-code

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,3 +8,6 @@ RUN bash -c 'set -euo pipefail && \
     tar -xzf /tmp/leeway.tar.gz -C /tmp && \
     install -m 755 /tmp/leeway /usr/local/bin/ && \
     rm /tmp/leeway.tar.gz /tmp/leeway'
+
+# Install claude-code globally
+RUN npm i -g @anthropic-ai/claude-code

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,6 @@
 		"dockerfile": "Dockerfile"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "18"
-		},
 		"ghcr.io/devcontainers/features/go:1": {
 			"version": "1.24"
 		},
@@ -14,7 +11,11 @@
 		"ghcr.io/dhoeric/features/google-cloud-cli:1": {},
 		"ghcr.io/devcontainers/features/aws-cli:1": {}
 	},
-	"forwardPorts": [8080, 3000, 9000],
+	"forwardPorts": [
+		8080,
+		3000,
+		9000
+	],
 	"portsAttributes": {
 		"8080": {
 			"label": "Application Server",

--- a/.gitpod/automations.yaml
+++ b/.gitpod/automations.yaml
@@ -46,3 +46,13 @@ tasks:
       - install-deps
     triggeredBy:
       - manual
+
+  setup-claude-code-key:
+    name: Key for Claude Code
+    command: |
+      [ -f /opt/.anthropic_key.sh ] && {
+        install -D -m 755 /opt/.anthropic_key.sh ~/.claude/.anthropic_key.sh
+        result=$(cat ~/.claude/settings.json 2>/dev/null || echo "{}" | jq '.apiKeyHelper = "~/.claude/.anthropic_key.sh"') && echo "$result" > ~/.claude/settings.json || true
+      } || true
+    triggeredBy:
+    - postEnvironmentStart


### PR DESCRIPTION
This ensure we have Claude Code installed on new environments. 

### Automate the login for new environments

Add a new File Secret (in your account) located in `/opt/.anthropic_key.sh` and paste `echo "sk-ant-..."` as value. This way you no longer need to authenticate on each new environment. 

<img width="749" alt="Screenshot 2025-06-13 at 12 51 33" src="https://github.com/user-attachments/assets/d7ab02ea-6fbd-41a6-b671-d2f3eaa27362" />

