### PR TITLE
feat: add in-flight checksumming to prevent TOCTU attacks on build artifacts

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -185,6 +185,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().StringToString("docker-build-options", nil, "Options passed to all 'docker build' commands")
 	cmd.Flags().Bool("slsa-cache-verification", false, "Enable SLSA verification for cached artifacts")
 	cmd.Flags().String("slsa-source-uri", "", "Expected source URI for SLSA verification (required when verification enabled)")
+	cmd.Flags().Bool("in-flight-checksums", false, "Enable checksumming of cache artifacts to prevent TOCTU attacks")
 	cmd.Flags().String("report", "", "Generate a HTML report after the build has finished. (e.g. --report myreport.html)")
 	cmd.Flags().String("report-segment", os.Getenv("LEEWAY_SEGMENT_KEY"), "Report build events to segment using the segment key (defaults to $LEEWAY_SEGMENT_KEY)")
 	cmd.Flags().Bool("report-github", os.Getenv("GITHUB_OUTPUT") != "", "Report package build success/failure to GitHub Actions using the GITHUB_OUTPUT environment variable")
@@ -318,6 +319,11 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		log.Fatal(err)
 	}
 
+	inFlightChecksums, err := cmd.Flags().GetBool("in-flight-checksums")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return []leeway.BuildOption{
 		leeway.WithLocalCache(localCache),
 		leeway.WithRemoteCache(remoteCache),
@@ -332,6 +338,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		leeway.WithCompressionDisabled(dontCompress),
 		leeway.WithFixedBuildDir(fixedBuildDir),
 		leeway.WithDisableCoverage(disableCoverage),
+		leeway.WithInFlightChecksums(inFlightChecksums),
 	}, localCache
 }
 

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -698,6 +698,13 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 		}
 	}
 
+	// Verify all cache artifact checksums before signing handoff
+	if ctx.InFlightChecksums {
+		if err := verifyAllArtifactChecksums(ctx); err != nil {
+			return fmt.Errorf("cache artifact integrity check failed - potential TOCTU attack detected: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -919,6 +919,14 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 		}
 	}
 
+	// Record checksum immediately after cache artifact creation
+	if cacheArtifactPath, exists := buildctx.LocalCache.Location(p); exists {
+		if err := buildctx.recordArtifactChecksum(cacheArtifactPath); err != nil {
+			log.WithError(err).WithField("package", p.FullName()).Warn("Failed to record cache artifact checksum")
+			// Don't fail build - this is defensive, not critical path
+		}
+	}
+
 	// Register newly built package
 	return buildctx.RegisterNewlyBuilt(p)
 }


### PR DESCRIPTION
## Description
Implements in-flight checksumming functionality to prevent Time-of-Check-Time-of-Use (TOCTU) attacks on build artifacts. This security enhancement validates cache artifacts during download to detect tampering between initial verification and actual use.

**Key Changes:**
- Added `downloadResult` struct to capture both file content and checksum validation results
- Enhanced `downloadFileAsync` to perform checksumming during download with structured error reporting
- Updated `downloadBothParallel` to collect and validate checksums from both download operations
- Added `--in-flight-checksums` CLI flag to enable the feature (disabled by default for backward compatibility)
- Integrated with existing `WithInFlightChecksums` build option system

The implementation maintains full backward compatibility while providing users with an opt-in security enhancement for production builds.

## Related Issue(s)

Fixes https://linear.app/ona-team/issue/CLC-1960/implement-in-flight-checksumming-leeway

## How to test
<!-- Provide steps to test this PR -->
1. Build the updated leeway binary: `go build -o leeway .`
2. Test CLI flag availability: `./leeway build --help` (verify `--in-flight-checksums` appears)
3. Test with flag enabled: `./leeway build --in-flight-checksums <target>`
4. Test without flag: `./leeway build <target>` (should work as before)
5. Run existing tests: `go test ./...` to ensure no regressions

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
