### PR TITLE
feat: enable Docker image export to cache instead of direct push 

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ config:
 config:
   # Dockerfile is the name of the Dockerfile to build. Automatically added to the package sources.
   dockerfile: "Dockerfile"
+  # exportToCache controls whether images are pushed directly or exported to cache
+  # - false (default): push directly to registry (legacy behavior)
+  # - true: export to cache for signing (enables SLSA L3 compliance)
+  # Can be overridden via --docker-export-to-cache flag or LEEWAY_DOCKER_EXPORT_TO_CACHE env var
+  exportToCache: false
   # Metadata produces a metadata.yaml file in the resulting package tarball.
   metadata:
     foo: bar
@@ -190,6 +195,12 @@ The name of this build argument is the package name of the dependency, transform
 - all uppercase.
 
 E.g. `component/nested:docker` becomes `COMPONENT_NESTED__DOCKER`.
+
+**For SLSA Level 3 compliance:** Set `exportToCache: true` to enable cache-based Docker image distribution with cryptographic signing. This can be overridden globally using:
+- CLI flag: `leeway build --docker-export-to-cache`
+- Environment variable: `LEEWAY_DOCKER_EXPORT_TO_CACHE=true`
+
+See `leeway build --help` for more details.
 
 ### Generic packages
 ```YAML

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -392,6 +392,8 @@ type buildOptions struct {
 	UseFixedBuildDir       bool
 	DisableCoverage        bool
 	InFlightChecksums      bool
+	DockerExportToCache    bool
+	DockerExportSet        bool // Track if explicitly set via CLI flag or env var
 
 	context *buildContext
 }
@@ -511,6 +513,15 @@ func WithDisableCoverage(disableCoverage bool) BuildOption {
 func WithInFlightChecksums(enabled bool) BuildOption {
 	return func(opts *buildOptions) error {
 		opts.InFlightChecksums = enabled
+		return nil
+	}
+}
+
+// WithDockerExportToCache configures whether Docker images should be exported to cache
+func WithDockerExportToCache(exportToCache bool, explicitlySet bool) BuildOption {
+	return func(opts *buildOptions) error {
+		opts.DockerExportToCache = exportToCache
+		opts.DockerExportSet = explicitlySet
 		return nil
 	}
 }
@@ -1690,6 +1701,19 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 		return nil, err
 	}
 
+	// Apply global export mode setting from build options (CLI flag or env var)
+	// This overrides the package-level configuration in BOTH directions
+	if buildctx.DockerExportSet {
+		if cfg.ExportToCache != buildctx.DockerExportToCache {
+			log.WithField("package", p.FullName()).
+				WithField("package_config", cfg.ExportToCache).
+				WithField("override_value", buildctx.DockerExportToCache).
+				Info("Docker export mode overridden via CLI flag or environment variable")
+		}
+		cfg.ExportToCache = buildctx.DockerExportToCache
+	}
+	// else: respect package config (no override)
+
 	var (
 		commands          = make(map[PackageBuildPhase][][]string)
 		imageDependencies = make(map[string]string)
@@ -1850,9 +1874,9 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 		))
 
 		commands[PackageBuildPhasePackage] = pkgcmds
-	} else if len(cfg.Image) > 0 {
+	} else if len(cfg.Image) > 0 && !cfg.ExportToCache {
 		// Image push workflow
-		log.WithField("images", cfg.Image).Debug("configuring image push")
+		log.WithField("images", cfg.Image).Debug("configuring image push (legacy behavior)")
 
 		for _, img := range cfg.Image {
 			pkgCommands = append(pkgCommands, [][]string{
@@ -1905,75 +1929,74 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 			Commands: commands,
 		}
 
-		// Enhanced subjects function with better error handling and logging
-		res.Subjects = func() ([]in_toto.Subject, error) {
-			subjectLogger := log.WithField("operation", "provenance-subjects")
-			subjectLogger.Debug("Calculating provenance subjects for pushed images")
+		// Add subjects function for provenance generation
+		res.Subjects = createDockerSubjectsFunction(version, cfg)
+	} else if len(cfg.Image) > 0 && cfg.ExportToCache {
+		// Export to cache for signing
+		log.WithField("package", p.FullName()).Debug("Exporting Docker image to cache")
 
-			// Get image digest with improved error handling
-			out, err := exec.Command("docker", "inspect", version).CombinedOutput()
-			if err != nil {
-				return nil, xerrors.Errorf("failed to inspect image %s: %w\nOutput: %s",
-					version, err, string(out))
-			}
+		// Export the image to tar
+		imageTarPath := filepath.Join(wd, "image.tar")
+		pkgCommands = append(pkgCommands,
+			[]string{"docker", "save", version, "-o", imageTarPath},
+		)
 
-			var inspectRes []struct {
-				ID          string   `json:"Id"`
-				RepoDigests []string `json:"RepoDigests"`
-			}
-
-			if err := json.Unmarshal(out, &inspectRes); err != nil {
-				return nil, xerrors.Errorf("cannot unmarshal Docker inspect response: %w", err)
-			}
-
-			if len(inspectRes) == 0 {
-				return nil, xerrors.Errorf("docker inspect returned empty result for image %s", version)
-			}
-
-			// Try to get digest from ID first (most reliable)
-			var digest common.DigestSet
-			if inspectRes[0].ID != "" {
-				segs := strings.Split(inspectRes[0].ID, ":")
-				if len(segs) == 2 {
-					digest = common.DigestSet{
-						segs[0]: segs[1],
-					}
-				}
-			}
-
-			// If we couldn't get digest from ID, try RepoDigests as fallback
-			if len(digest) == 0 && len(inspectRes[0].RepoDigests) > 0 {
-				for _, repoDigest := range inspectRes[0].RepoDigests {
-					parts := strings.Split(repoDigest, "@")
-					if len(parts) == 2 {
-						digestParts := strings.Split(parts[1], ":")
-						if len(digestParts) == 2 {
-							digest = common.DigestSet{
-								digestParts[0]: digestParts[1],
-							}
-							break
-						}
-					}
-				}
-			}
-
-			if len(digest) == 0 {
-				return nil, xerrors.Errorf("could not determine digest for image %s", version)
-			}
-
-			subjectLogger.WithField("digest", digest).Debug("Found image digest")
-
-			// Create subjects for each image
-			result := make([]in_toto.Subject, 0, len(cfg.Image))
-			for _, tag := range cfg.Image {
-				result = append(result, in_toto.Subject{
-					Name:   tag,
-					Digest: digest,
-				})
-			}
-
-			return result, nil
+		// Store image names for later use
+		for _, img := range cfg.Image {
+			pkgCommands = append(pkgCommands,
+				[]string{"sh", "-c", fmt.Sprintf("echo %s >> %s", img, dockerImageNamesFiles)},
+			)
 		}
+
+		// Add metadata file
+		if len(cfg.Metadata) > 0 {
+			metadataContent, err := yaml.Marshal(cfg.Metadata)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to marshal metadata: %w", err)
+			}
+			encodedMetadata := base64.StdEncoding.EncodeToString(metadataContent)
+			pkgCommands = append(pkgCommands,
+				[]string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d > %s", encodedMetadata, dockerMetadataFile)},
+			)
+		}
+
+		// Package everything into final tar.gz
+		sourcePaths := []string{"./image.tar", fmt.Sprintf("./%s", dockerImageNamesFiles), "./docker-export-metadata.json"}
+		if len(cfg.Metadata) > 0 {
+			sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", dockerMetadataFile))
+		}
+		if p.C.W.Provenance.Enabled {
+			sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", provenanceBundleFilename))
+		}
+		if p.C.W.SBOM.Enabled {
+			sourcePaths = append(sourcePaths,
+				fmt.Sprintf("./%s", sbomBaseFilename+sbomCycloneDXFileExtension),
+				fmt.Sprintf("./%s", sbomBaseFilename+sbomSPDXFileExtension),
+				fmt.Sprintf("./%s", sbomBaseFilename+sbomSyftFileExtension),
+			)
+		}
+
+		archiveCmd := BuildTarCommand(
+			WithOutputFile(result),
+			WithSourcePaths(sourcePaths...),
+			WithCompression(!buildctx.DontCompress),
+		)
+		pkgCommands = append(pkgCommands, archiveCmd)
+
+		commands[PackageBuildPhasePackage] = pkgCommands
+
+		// Initialize res with commands
+		res = &packageBuild{
+			Commands: commands,
+		}
+
+		// Add PostProcess to create structured metadata file
+		res.PostProcess = func(buildCtx *buildContext, pkg *Package, buildDir string) error {
+			return createDockerExportMetadata(buildDir, version, cfg)
+		}
+
+		// Add subjects function for provenance generation
+		res.Subjects = createDockerSubjectsFunction(version, cfg)
 	}
 
 	return res, nil
@@ -2032,6 +2055,118 @@ func extractImageNameFromCache(pkgName, cacheBundleFN string) (imgname string, e
 
 	return "", nil
 }
+
+// createDockerSubjectsFunction creates a function that generates SLSA provenance subjects for Docker images
+func createDockerSubjectsFunction(version string, cfg DockerPkgConfig) func() ([]in_toto.Subject, error) {
+	return func() ([]in_toto.Subject, error) {
+		subjectLogger := log.WithField("operation", "provenance-subjects")
+		subjectLogger.Debug("Calculating provenance subjects for Docker images")
+
+		// Get image digest with improved error handling
+		out, err := exec.Command("docker", "inspect", version).CombinedOutput()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to inspect image %s: %w\nOutput: %s",
+				version, err, string(out))
+		}
+
+		var inspectRes []struct {
+			ID          string   `json:"Id"`
+			RepoDigests []string `json:"RepoDigests"`
+		}
+
+		if err := json.Unmarshal(out, &inspectRes); err != nil {
+			return nil, xerrors.Errorf("cannot unmarshal Docker inspect response: %w", err)
+		}
+
+		if len(inspectRes) == 0 {
+			return nil, xerrors.Errorf("docker inspect returned empty result for image %s", version)
+		}
+
+		// Try to get digest from ID first (most reliable)
+		var digest common.DigestSet
+		if inspectRes[0].ID != "" {
+			segs := strings.Split(inspectRes[0].ID, ":")
+			if len(segs) == 2 {
+				digest = common.DigestSet{
+					segs[0]: segs[1],
+				}
+			}
+		}
+
+		// If we couldn't get digest from ID, try RepoDigests as fallback
+		if len(digest) == 0 && len(inspectRes[0].RepoDigests) > 0 {
+			for _, repoDigest := range inspectRes[0].RepoDigests {
+				parts := strings.Split(repoDigest, "@")
+				if len(parts) == 2 {
+					digestParts := strings.Split(parts[1], ":")
+					if len(digestParts) == 2 {
+						digest = common.DigestSet{
+							digestParts[0]: digestParts[1],
+						}
+						break
+					}
+				}
+			}
+		}
+
+		if len(digest) == 0 {
+			return nil, xerrors.Errorf("could not determine digest for image %s", version)
+		}
+
+		subjectLogger.WithField("digest", digest).Debug("Found image digest")
+
+		// Create subjects for each image
+		result := make([]in_toto.Subject, 0, len(cfg.Image))
+		for _, tag := range cfg.Image {
+			result = append(result, in_toto.Subject{
+				Name:   tag,
+				Digest: digest,
+			})
+		}
+
+		return result, nil
+	}
+}
+
+// DockerImageMetadata holds metadata for exported Docker images
+type DockerImageMetadata struct {
+	ImageNames   []string          `json:"image_names" yaml:"image_names"`
+	BuiltVersion string            `json:"built_version" yaml:"built_version"`
+	Digest       string            `json:"digest,omitempty" yaml:"digest,omitempty"`
+	BuildTime    time.Time         `json:"build_time" yaml:"build_time"`
+	CustomMeta   map[string]string `json:"custom_metadata,omitempty" yaml:"custom_metadata,omitempty"`
+}
+
+// createDockerExportMetadata creates metadata file for exported Docker images
+func createDockerExportMetadata(wd, version string, cfg DockerPkgConfig) error {
+	metadata := DockerImageMetadata{
+		ImageNames:   cfg.Image,
+		BuiltVersion: version,
+		BuildTime:    time.Now(),
+		CustomMeta:   cfg.Metadata,
+	}
+
+	// Try to get image digest if available
+	inspectCmd := exec.Command("docker", "inspect", "--format={{index .Id}}", version)
+	if output, err := inspectCmd.Output(); err == nil {
+		metadata.Digest = strings.TrimSpace(string(output))
+	}
+
+	// Write as JSON for easy parsing
+	metadataBytes, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Docker metadata: %w", err)
+	}
+
+	metadataPath := filepath.Join(wd, "docker-export-metadata.json")
+	if err := os.WriteFile(metadataPath, metadataBytes, 0644); err != nil {
+		return fmt.Errorf("failed to write Docker metadata: %w", err)
+	}
+
+	log.WithField("path", metadataPath).Debug("Created Docker export metadata")
+	return nil
+}
+
 
 // Update buildGeneric to use compression arg helper
 func (p *Package) buildGeneric(buildctx *buildContext, wd, result string) (res *packageBuild, err error) {

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -546,6 +546,11 @@ type DockerPkgConfig struct {
 	BuildArgs  map[string]string `yaml:"buildArgs,omitempty"`
 	Squash     bool              `yaml:"squash,omitempty"`
 	Metadata   map[string]string `yaml:"metadata,omitempty"`
+
+	// ExportToCache controls whether Docker images are exported to cache instead of pushed immediately.
+	// When true, images are saved as .tar files and go through the standard cache flow.
+	// When false (default), images are pushed directly to registries (legacy behavior).
+	ExportToCache bool `yaml:"exportToCache,omitempty"`
 }
 
 // AdditionalSources returns a list of unresolved sources coming in through this configuration


### PR DESCRIPTION
## Description

This PR adds support for exporting Docker images to cache instead of pushing them directly to registries, enabling SLSA Level 3 compliance for Docker packages.

### Problem
Currently, Docker images are pushed directly to registries during the build phase, bypassing Leeway's cache signing workflow. This prevents SLSA Level 3 compliance because:
- Build jobs need write access to registries (can't be read-only)
- Images can't go through the signing flow like other artifacts
- No separation between build, sign, and push operations

### Solution
Adds an optional `exportToCache` field to Docker package configuration:
- **`false` (default)**: Legacy behavior - push directly to registry
- **`true`**: Export image to cache as `.tar` file for signing

### Key Features
- **Backward Compatible**: Default behavior unchanged
- **Proper Precedence**: CLI flag > Environment variable > Package config
- **Bidirectional Override**: Can enable OR disable export mode
- **Consistent with Leeway Patterns**: Follows existing flag/env var conventions

### Changes
1. **Configuration**: Add `exportToCache` field to `DockerPkgConfig`
2. **Build Logic**: Implement export-to-cache path that packages images as tar files
3. **Metadata**: Structured metadata for exported images (names, digest, build time)
4. **CLI Flag**: `--docker-export-to-cache` with proper precedence handling
5. **Environment Variable**: `LEEWAY_DOCKER_EXPORT_TO_CACHE` for CI/CD
6. **Tests**: Comprehensive unit tests including critical bidirectional override test
7. **Documentation**: Updated README with usage examples

### Usage Examples

**Package Configuration:**
```yaml
packages:
  - name: backend
    type: docker
    config:
      dockerfile: Dockerfile
      exportToCache: true  # Enable export mode
      image:
        - registry.example.com/backend:latest
```

**CLI Override:**
```bash
# Enable for all packages
leeway build --docker-export-to-cache :backend

# Disable even if package config has it enabled
leeway build --docker-export-to-cache=false :backend
```

**Environment Variable:**
```bash
# CI/CD pipeline
export LEEWAY_DOCKER_EXPORT_TO_CACHE=true
leeway build :all
```

### Cache Artifact Structure
When `exportToCache: true`, the cache artifact contains:
- `image.tar` - Full Docker image (from `docker save`)
- `imgnames.txt` - List of image tags
- `docker-export-metadata.json` - Structured metadata (digest, build time, etc.)
- `metadata.yaml` - Custom metadata (if configured)
- Optional: provenance and SBOM files

## Related Issue(s)

Fixes https://linear.app/ona-team/issue/CLC-2009/docker-export-mode-for-slsa-l3-compliance-leeway

Depends on #242
Depends on #245 

## How to test

### 1. Test Default Behavior (Backward Compatibility)
```bash
# Build a Docker package without exportToCache
leeway build :your-docker-package

# Should push directly to registry (legacy behavior)
```

### 2. Test Export Mode via Package Config
```yaml
# In BUILD.yaml
packages:
  - name: test-image
    type: docker
    config:
      dockerfile: Dockerfile
      exportToCache: true
      image:
        - test:latest
```
```bash
leeway build :test-image

# Verify cache artifact contains image.tar
tar -tzf ~/.cache/leeway/test-image-*.tar.gz | grep image.tar
```

### 3. Test CLI Flag Override
```bash
# Enable export mode via CLI (overrides package config)
leeway build --docker-export-to-cache :test-image

# Disable export mode via CLI (overrides package config)
leeway build --docker-export-to-cache=false :test-image
```

### 4. Test Environment Variable
```bash
# Enable globally via env var
export LEEWAY_DOCKER_EXPORT_TO_CACHE=true
leeway build :test-image

# CLI flag should still override env var
leeway build --docker-export-to-cache=false :test-image
```

### 5. Test Metadata Extraction
```bash
# Build with export mode
leeway build --docker-export-to-cache :test-image

# Extract and verify metadata
tar -xzf ~/.cache/leeway/test-image-*.tar.gz docker-export-metadata.json
cat docker-export-metadata.json
# Should show: image_names, built_version, digest, build_time
```

### 6. Run Unit Tests
```bash
go test ./pkg/leeway/... -v -run "TestDockerPkgConfig_ExportToCache|TestBuildDocker_ExportToCache|TestDockerPackage_BuildContextOverride"
```

## Documentation

* `leeway build --help` has been updated
 * README.md has been updated with:
   - `exportToCache` field documentation in Docker packages section
   - SLSA L3 compliance usage note
   - CLI flag and environment variable examples
   - Reference to `leeway build --help`

/hold
