### PR TITLE
feat: auto-enable SLSA L3 features when `provenance.slsa` is true

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -178,7 +178,7 @@ func init() {
 }
 
 func addBuildFlags(cmd *cobra.Command) {
-	cacheDefault := os.Getenv("LEEWAY_DEFAULT_CACHE_LEVEL")
+	cacheDefault := os.Getenv(EnvvarDefaultCacheLevel)
 	if cacheDefault == "" {
 		cacheDefault = "remote"
 	}
@@ -204,7 +204,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().String("slsa-source-uri", "", "Expected source URI for SLSA verification (required when verification enabled)")
 	cmd.Flags().Bool("in-flight-checksums", false, "Enable checksumming of cache artifacts to prevent TOCTU attacks")
 	cmd.Flags().String("report", "", "Generate a HTML report after the build has finished. (e.g. --report myreport.html)")
-	cmd.Flags().String("report-segment", os.Getenv("LEEWAY_SEGMENT_KEY"), "Report build events to segment using the segment key (defaults to $LEEWAY_SEGMENT_KEY)")
+	cmd.Flags().String("report-segment", os.Getenv(EnvvarSegmentKey), "Report build events to segment using the segment key (defaults to $LEEWAY_SEGMENT_KEY)")
 	cmd.Flags().Bool("report-github", os.Getenv("GITHUB_OUTPUT") != "", "Report package build success/failure to GitHub Actions using the GITHUB_OUTPUT environment variable")
 	cmd.Flags().Bool("fixed-build-dir", true, "Use a fixed build directory for each package, instead of based on the package version, to better utilize caches based on absolute paths (defaults to true)")
 	cmd.Flags().Bool("docker-export-to-cache", false, "Export Docker images to cache instead of pushing directly (enables SLSA L3 compliance)")
@@ -217,7 +217,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 	// - Workspace auto-set: Low priority (package config can override)
 	dockerExportEnvSet := false
 	dockerExportEnvValue := false
-	if envVal := os.Getenv("LEEWAY_DOCKER_EXPORT_TO_CACHE"); envVal != "" {
+	if envVal := os.Getenv(EnvvarDockerExportToCache); envVal != "" {
 		dockerExportEnvSet = true
 		dockerExportEnvValue = (envVal == "true" || envVal == "1")
 		log.WithField("value", envVal).Debug("User explicitly set LEEWAY_DOCKER_EXPORT_TO_CACHE before workspace loading")

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -116,7 +116,7 @@ func TestInFlightChecksumsEnvironmentVariable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set environment variable using t.Setenv for proper cleanup
 			if tt.envValue != "" {
-				t.Setenv("LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS", tt.envValue)
+				t.Setenv(EnvvarEnableInFlightChecksums, tt.envValue)
 			}
 
 			// Create test command
@@ -136,7 +136,7 @@ func TestInFlightChecksumsEnvironmentVariable(t *testing.T) {
 			}
 
 			// Test the actual logic from getBuildOpts
-			inFlightChecksumsDefault := os.Getenv("LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS") == "true"
+			inFlightChecksumsDefault := os.Getenv(EnvvarEnableInFlightChecksums) == "true"
 			inFlightChecksums, err := cmd.Flags().GetBool("in-flight-checksums")
 			if err != nil {
 				t.Fatalf("failed to get flag: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,24 @@ const (
 
 	// EnvvarEnableInFlightChecksums enables in-flight checksumming of cache artifacts
 	EnvvarEnableInFlightChecksums = "LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS"
+
+	// EnvvarDockerExportToCache controls whether Docker images are exported to cache instead of pushed directly
+	EnvvarDockerExportToCache = "LEEWAY_DOCKER_EXPORT_TO_CACHE"
+
+	// EnvvarDefaultCacheLevel sets the default cache level
+	EnvvarDefaultCacheLevel = "LEEWAY_DEFAULT_CACHE_LEVEL"
+
+	// EnvvarSegmentKey configures Segment analytics key
+	EnvvarSegmentKey = "LEEWAY_SEGMENT_KEY"
+
+	// EnvvarTrace enables tracing output
+	EnvvarTrace = "LEEWAY_TRACE"
+
+	// EnvvarProvenanceKeypath configures provenance key path
+	EnvvarProvenanceKeypath = "LEEWAY_PROVENANCE_KEYPATH"
+
+	// EnvvarExperimental enables experimental features
+	EnvvarExperimental = "LEEWAY_EXPERIMENTAL"
 )
 
 const (
@@ -116,7 +134,7 @@ variables have an effect on leeway:
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	tp := os.Getenv("LEEWAY_TRACE")
+	tp := os.Getenv(EnvvarTrace)
 	if tp != "" {
 		f, err := os.OpenFile(tp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 		if err != nil {
@@ -166,7 +184,7 @@ func getWorkspace() (leeway.Workspace, error) {
 		return leeway.Workspace{}, err
 	}
 
-	return leeway.FindWorkspace(workspace, args, variant, os.Getenv("LEEWAY_PROVENANCE_KEYPATH"))
+	return leeway.FindWorkspace(workspace, args, variant, os.Getenv(EnvvarProvenanceKeypath))
 }
 
 func getBuildArgs() (leeway.Arguments, error) {
@@ -186,7 +204,7 @@ func getBuildArgs() (leeway.Arguments, error) {
 }
 
 func addExperimentalCommand(parent, child *cobra.Command) {
-	if os.Getenv("LEEWAY_EXPERIMENTAL") != "true" {
+	if os.Getenv(EnvvarExperimental) != "true" {
 		return
 	}
 

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -90,6 +90,12 @@ const (
 	// Defaults to "network".
 	EnvvarYarnMutex = "LEEWAY_YARN_MUTEX"
 
+	// EnvvarDockerExportToCache controls whether Docker images are exported to cache instead of pushed directly
+	EnvvarDockerExportToCache = "LEEWAY_DOCKER_EXPORT_TO_CACHE"
+
+	// EnvvarWorkspaceRoot names the environment variable for workspace root path
+	EnvvarWorkspaceRoot = "LEEWAY_WORKSPACE_ROOT"
+
 	// dockerImageNamesFiles is the name of the file store in poushed Docker build artifacts
 	// which contains the names of the Docker images we just pushed
 	dockerImageNamesFiles = "imgnames.txt"
@@ -1716,7 +1722,7 @@ func determineDockerExportMode(p *Package, cfg *DockerPkgConfig, buildctx *build
 	// Layer 5 & 4: Start with workspace default
 	// At this point, workspace loading already auto-set LEEWAY_DOCKER_EXPORT_TO_CACHE
 	// if provenance.slsa: true
-	envExport := os.Getenv("LEEWAY_DOCKER_EXPORT_TO_CACHE")
+	envExport := os.Getenv(EnvvarDockerExportToCache)
 	if envExport == "true" || envExport == "1" {
 		exportToCache = true
 		source = "workspace_default"
@@ -2380,7 +2386,7 @@ func executeCommandsForPackage(buildctx *buildContext, p *Package, wd string, co
 	}
 
 	env := append(os.Environ(), p.Environment...)
-	env = append(env, fmt.Sprintf("LEEWAY_WORKSPACE_ROOT=%s", p.C.W.Origin))
+	env = append(env, fmt.Sprintf("%s=%s", EnvvarWorkspaceRoot, p.C.W.Origin))
 	for _, cmd := range commands {
 		if len(cmd) == 0 {
 			continue // Skip empty commands

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1955,7 +1955,7 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 		))
 
 		commands[PackageBuildPhasePackage] = pkgcmds
-	} else if len(cfg.Image) > 0 && (cfg.ExportToCache == nil || !*cfg.ExportToCache) {
+	} else if len(cfg.Image) > 0 && !*cfg.ExportToCache {
 		// Image push workflow
 		log.WithField("images", cfg.Image).Debug("configuring image push (legacy behavior)")
 
@@ -2012,7 +2012,7 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 
 		// Add subjects function for provenance generation
 		res.Subjects = createDockerSubjectsFunction(version, cfg)
-	} else if len(cfg.Image) > 0 && cfg.ExportToCache != nil && *cfg.ExportToCache {
+	} else if len(cfg.Image) > 0 && *cfg.ExportToCache {
 		// Export to cache for signing
 		log.WithField("package", p.FullName()).Debug("Exporting Docker image to cache")
 

--- a/pkg/leeway/build_test.go
+++ b/pkg/leeway/build_test.go
@@ -266,9 +266,9 @@ func TestDockerExport_PrecedenceHierarchy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup environment to simulate workspace auto-set
 			if tt.workspaceEnvSet {
-				t.Setenv("LEEWAY_DOCKER_EXPORT_TO_CACHE", "true")
+				t.Setenv(leeway.EnvvarDockerExportToCache, "true")
 			} else {
-				t.Setenv("LEEWAY_DOCKER_EXPORT_TO_CACHE", "")
+				t.Setenv(leeway.EnvvarDockerExportToCache, "")
 			}
 
 			// Create mock build context
@@ -296,7 +296,7 @@ func TestDockerExport_PrecedenceHierarchy(t *testing.T) {
 			var source string
 
 			// Layer 5 & 4: Workspace default
-			envExport := os.Getenv("LEEWAY_DOCKER_EXPORT_TO_CACHE")
+			envExport := os.Getenv(leeway.EnvvarDockerExportToCache)
 			if envExport == "true" || envExport == "1" {
 				exportToCache = true
 				source = "workspace_default"

--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -549,8 +549,10 @@ type DockerPkgConfig struct {
 
 	// ExportToCache controls whether Docker images are exported to cache instead of pushed immediately.
 	// When true, images are saved as .tar files and go through the standard cache flow.
-	// When false (default), images are pushed directly to registries (legacy behavior).
-	ExportToCache bool `yaml:"exportToCache,omitempty"`
+	// When false, images are pushed directly to registries (legacy behavior).
+	// When nil (not set), inherits from workspace SLSA configuration.
+	// Using pointer allows distinguishing "not set" from "explicitly false".
+	ExportToCache *bool `yaml:"exportToCache,omitempty"`
 }
 
 // AdditionalSources returns a list of unresolved sources coming in through this configuration

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -30,6 +30,17 @@ import (
 	"github.com/gitpod-io/leeway/pkg/doublestar"
 )
 
+const (
+	// EnvvarSLSACacheVerification enables SLSA verification for cached artifacts
+	EnvvarSLSACacheVerification = "LEEWAY_SLSA_CACHE_VERIFICATION"
+
+	// EnvvarSLSASourceURI configures the expected source URI for SLSA verification
+	EnvvarSLSASourceURI = "LEEWAY_SLSA_SOURCE_URI"
+
+	// EnvvarEnableInFlightChecksums enables in-flight checksumming of cache artifacts
+	EnvvarEnableInFlightChecksums = "LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS"
+)
+
 // Workspace is the root container of all compoments. All components are named relative
 // to the origin of this workspace.
 type Workspace struct {
@@ -77,23 +88,23 @@ func (w *Workspace) ApplySLSADefaults() {
 	log.Info("SLSA provenance enabled - activating SLSA L3 runtime features")
 
 	// Auto-enable cache verification (global feature)
-	if setEnvDefault("LEEWAY_SLSA_CACHE_VERIFICATION", "true") {
+	if setEnvDefault(EnvvarSLSACacheVerification, "true") {
 		log.Debug("Auto-enabled: LEEWAY_SLSA_CACHE_VERIFICATION=true")
 	}
 
 	// Auto-enable in-flight checksumming (global feature)
-	if setEnvDefault("LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS", "true") {
+	if setEnvDefault(EnvvarEnableInFlightChecksums, "true") {
 		log.Debug("Auto-enabled: LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS=true")
 	}
 
 	// Auto-enable Docker export mode (workspace default, packages can override)
-	if setEnvDefault("LEEWAY_DOCKER_EXPORT_TO_CACHE", "true") {
+	if setEnvDefault(EnvvarDockerExportToCache, "true") {
 		log.Debug("Auto-enabled: LEEWAY_DOCKER_EXPORT_TO_CACHE=true (package config can override)")
 	}
 
 	// Auto-set source URI from Git origin
 	if w.Git.Origin != "" {
-		if setEnvDefault("LEEWAY_SLSA_SOURCE_URI", w.Git.Origin) {
+		if setEnvDefault(EnvvarSLSASourceURI, w.Git.Origin) {
 			log.WithField("source_uri", w.Git.Origin).Debug("Auto-set SLSA source URI from Git origin")
 		}
 	}

--- a/pkg/leeway/workspace_test.go
+++ b/pkg/leeway/workspace_test.go
@@ -329,10 +329,10 @@ func TestWorkspace_ApplySLSADefaults(t *testing.T) {
 			gitOrigin:         "github.com/gitpod-io/leeway",
 			existingEnvVars:   map[string]string{},
 			expectedEnvVars: map[string]string{
-				"LEEWAY_SLSA_CACHE_VERIFICATION":    "true",
-				"LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS": "true",
-				"LEEWAY_DOCKER_EXPORT_TO_CACHE":     "true",
-				"LEEWAY_SLSA_SOURCE_URI":            "github.com/gitpod-io/leeway",
+				leeway.EnvvarSLSACacheVerification:    "true",
+				leeway.EnvvarEnableInFlightChecksums: "true",
+				leeway.EnvvarDockerExportToCache:     "true",
+				leeway.EnvvarSLSASourceURI:            "github.com/gitpod-io/leeway",
 			},
 		},
 		{
@@ -341,10 +341,10 @@ func TestWorkspace_ApplySLSADefaults(t *testing.T) {
 			provenanceSLSA:    false,
 			existingEnvVars:   map[string]string{},
 			expectedEnvVars: map[string]string{
-				"LEEWAY_SLSA_CACHE_VERIFICATION":    "",
-				"LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS": "",
-				"LEEWAY_DOCKER_EXPORT_TO_CACHE":     "",
-				"LEEWAY_SLSA_SOURCE_URI":            "",
+				leeway.EnvvarSLSACacheVerification:    "",
+				leeway.EnvvarEnableInFlightChecksums: "",
+				leeway.EnvvarDockerExportToCache:     "",
+				leeway.EnvvarSLSASourceURI:            "",
 			},
 		},
 		{
@@ -353,10 +353,10 @@ func TestWorkspace_ApplySLSADefaults(t *testing.T) {
 			provenanceSLSA:    true,
 			existingEnvVars:   map[string]string{},
 			expectedEnvVars: map[string]string{
-				"LEEWAY_SLSA_CACHE_VERIFICATION":    "",
-				"LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS": "",
-				"LEEWAY_DOCKER_EXPORT_TO_CACHE":     "",
-				"LEEWAY_SLSA_SOURCE_URI":            "",
+				leeway.EnvvarSLSACacheVerification:    "",
+				leeway.EnvvarEnableInFlightChecksums: "",
+				leeway.EnvvarDockerExportToCache:     "",
+				leeway.EnvvarSLSASourceURI:            "",
 			},
 		},
 		{
@@ -365,14 +365,14 @@ func TestWorkspace_ApplySLSADefaults(t *testing.T) {
 			provenanceSLSA:    true,
 			gitOrigin:         "github.com/gitpod-io/leeway",
 			existingEnvVars: map[string]string{
-				"LEEWAY_SLSA_CACHE_VERIFICATION":    "false",
-				"LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS": "false",
+				leeway.EnvvarSLSACacheVerification:    "false",
+				leeway.EnvvarEnableInFlightChecksums: "false",
 			},
 			expectedEnvVars: map[string]string{
-				"LEEWAY_SLSA_CACHE_VERIFICATION":    "false", // Not overridden
-				"LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS": "false", // Not overridden
-				"LEEWAY_DOCKER_EXPORT_TO_CACHE":     "true",  // Set (wasn't present)
-				"LEEWAY_SLSA_SOURCE_URI":            "github.com/gitpod-io/leeway",
+				leeway.EnvvarSLSACacheVerification:    "false", // Not overridden
+				leeway.EnvvarEnableInFlightChecksums: "false", // Not overridden
+				leeway.EnvvarDockerExportToCache:     "true",  // Set (wasn't present)
+				leeway.EnvvarSLSASourceURI:            "github.com/gitpod-io/leeway",
 			},
 		},
 		{
@@ -382,10 +382,10 @@ func TestWorkspace_ApplySLSADefaults(t *testing.T) {
 			gitOrigin:         "",
 			existingEnvVars:   map[string]string{},
 			expectedEnvVars: map[string]string{
-				"LEEWAY_SLSA_CACHE_VERIFICATION":    "true",
-				"LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS": "true",
-				"LEEWAY_DOCKER_EXPORT_TO_CACHE":     "true",
-				"LEEWAY_SLSA_SOURCE_URI":            "", // Not set without Git origin
+				leeway.EnvvarSLSACacheVerification:    "true",
+				leeway.EnvvarEnableInFlightChecksums: "true",
+				leeway.EnvvarDockerExportToCache:     "true",
+				leeway.EnvvarSLSASourceURI:            "", // Not set without Git origin
 			},
 		},
 	}
@@ -394,10 +394,10 @@ func TestWorkspace_ApplySLSADefaults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clear environment variables for clean test
 			envVarsToCheck := []string{
-				"LEEWAY_SLSA_CACHE_VERIFICATION",
-				"LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS",
-				"LEEWAY_DOCKER_EXPORT_TO_CACHE",
-				"LEEWAY_SLSA_SOURCE_URI",
+				leeway.EnvvarSLSACacheVerification,
+				leeway.EnvvarEnableInFlightChecksums,
+				leeway.EnvvarDockerExportToCache,
+				leeway.EnvvarSLSASourceURI,
 			}
 			for _, key := range envVarsToCheck {
 				t.Setenv(key, "")


### PR DESCRIPTION
## Description

This PR implements automatic SLSA Level 3 feature activation when `provenance.slsa: true` is configured in WORKSPACE.yaml.

### Problem

Previously, SLSA L3 features required manual configuration of multiple environment variables:
- Users had to set 4 different environment variables manually
- Configuration was scattered across workspace and CI/CD scripts
- `provenance.slsa: true` only enabled metadata generation, not runtime features
- Artifacts built with/without SLSA were indistinguishable in cache (hash collision risk)

### Solution

When `provenance.slsa: true` is set, automatically enable:
- ✅ Cache verification (`LEEWAY_SLSA_CACHE_VERIFICATION=true`)
- ✅ In-flight checksums (`LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS=true`)
- ✅ Docker export mode (`LEEWAY_DOCKER_EXPORT_TO_CACHE=true`)
- ✅ Source URI (`LEEWAY_SLSA_SOURCE_URI` from Git origin)

### Key Changes

**1. Workspace Auto-Enablement**
```yaml
# WORKSPACE.yaml
provenance:
  enabled: true
  slsa: true    # ← Automatically enables all SLSA L3 features
```

**2. Five-Layer Precedence for Docker Export**
```
1. CLI flag (--docker-export-to-cache)           [Highest]
2. User environment variable (set before build)
3. Package config (exportToCache in BUILD.yaml)
4. Workspace default (auto-set by provenance.slsa)
5. Global default (false - legacy)               [Lowest]
```

**3. Package-Level Override**
```yaml
# BUILD.yaml - opt out of workspace default
packages:
  - name: legacy-service
    type: docker
    config:
      exportToCache: false  # Explicit override
```

**4. Artifact Distinguishability**

Artifacts built with SLSA include `provenance: version=3 slsa` in manifest, ensuring different cache keys than legacy builds.

### Technical Changes

- Changed `ExportToCache bool` → `ExportToCache *bool` (distinguishes "not set" from "explicitly false")
- Added `ApplySLSADefaults()` in workspace loading
- Track user-set env vars before workspace loads (enables precedence)
- Implement 5-layer precedence in `buildDocker()`
- 16 new test scenarios covering all precedence layers

### Usage Examples

**Enable SLSA L3 globally:**
```yaml
# WORKSPACE.yaml
provenance:
  enabled: true
  slsa: true    # All packages inherit SLSA features
```

**Package opts out:**
```yaml
packages:
  - name: legacy
    type: docker
    config:
      exportToCache: false  # Push directly (legacy mode)
```

**User override for testing:**
```bash
export LEEWAY_DOCKER_EXPORT_TO_CACHE=false
leeway build :backend
```

**CLI override:**
```bash
leeway build --docker-export-to-cache=true :backend
```

### Backward Compatibility

✅ 100% backward compatible:
- Existing workspaces without `provenance.slsa: true` unchanged
- Explicit environment variables take precedence over auto-set
- All existing tests passing

## Related Issue(s)

Fixes https://linear.app/ona-team/issue/CLC-2018/implement-slsa-l3-workspace-driven-auto-enablement-leeway

## How to test

### 1. Verify Auto-Enablement

```bash
cat > WORKSPACE.yaml <<EOF
provenance:
  enabled: true
  slsa: true
EOF

leeway build -v :package 2>&1 | grep "SLSA provenance enabled"
# Should see: "SLSA provenance enabled - activating SLSA L3 runtime features"

env | grep LEEWAY_
# Should see all 4 env vars set to "true"
```

### 2. Test Precedence Layers

```bash
# Layer 4: Workspace default (SLSA enabled)
leeway build -v :docker-pkg 2>&1 | grep "workspace_default"

# Layer 3: Package config overrides workspace
# Add exportToCache: false to BUILD.yaml
leeway build -v :docker-pkg 2>&1 | grep "package_config"

# Layer 2: User env var overrides package
export LEEWAY_DOCKER_EXPORT_TO_CACHE=true
leeway build -v :docker-pkg 2>&1 | grep "user_env_var"

# Layer 1: CLI flag overrides everything
leeway build --docker-export-to-cache=false -v :docker-pkg 2>&1 | grep "cli_flag"
```

### 3. Test Artifact Distinguishability

```bash
# Build WITHOUT SLSA
cat > WORKSPACE.yaml <<EOF
provenance:
  enabled: false
EOF
leeway build :package
VERSION_1=$(leeway describe version :package)

# Build WITH SLSA
cat > WORKSPACE.yaml <<EOF
provenance:
  enabled: true
  slsa: true
EOF
leeway build :package
VERSION_2=$(leeway describe version :package)

# Verify different hashes
test "$VERSION_1" != "$VERSION_2" && echo "✅ Artifacts distinguishable"

# Check manifest
leeway describe manifest :package | grep "provenance: version=3 slsa"
```

### 4. Run Tests

```bash
# New tests
go test ./pkg/leeway/workspace_test.go -v -run TestWorkspace_ApplySLSADefaults
go test ./pkg/leeway/build_test.go -v -run TestDockerExport_PrecedenceHierarchy

# Full suite
go test ./pkg/leeway/... -v
```

**Expected:** 16 new test scenarios, all passing

### 5. Test Backward Compatibility

```bash
# Existing workspace without provenance.slsa
cat > WORKSPACE.yaml <<EOF
# No provenance config
EOF
leeway build :package
# Should work exactly as before

# User env vars preserved
export LEEWAY_DOCKER_EXPORT_TO_CACHE=false
cat > WORKSPACE.yaml <<EOF
provenance:
  enabled: true
  slsa: true
EOF
env | grep LEEWAY_DOCKER_EXPORT_TO_CACHE
# Should show: false (user value not overwritten)
```

## Documentation


* README.md updated with:
    - Fixed SLSA version reference (v0.1 → v0.2)
    - "Automatic SLSA L3 Feature Activation" section
    - Configuration precedence documentation
    - Usage examples and troubleshooting

/hold