### PR TITLE
ci: support relese candidates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,3 +31,6 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+release:
+  prerelease: auto


### PR DESCRIPTION
## Description

Enables support for releasing RC versions of Leeway.

## Related Issue(s)

Relates to https://linear.app/ona-team/issue/CLC-1963/enhance-build-job-with-leeway-security-features
Relates to https://linear.app/ona-team/issue/CLC-1962/add-ci-signing-step-using-the-new-leeway-signing-command

## How to test

```bash
git tag vX.Y.Z-rc1 'm "rc1: bla bla bla"
git push origin vX.Y.Z-rc1
```

## Documentation

NONE
