### PR TITLE
fix(signing): explicitly fetch GitHub OIDC token for Sigstore

### DIFF
--- a/pkg/leeway/signing/attestation.go
+++ b/pkg/leeway/signing/attestation.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -245,6 +247,17 @@ func signProvenanceWithSigstore(ctx context.Context, statement *in_toto.Statemen
 
 	// Configure Fulcio for GitHub OIDC if we have a token
 	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN") != "" {
+		// Fetch the GitHub OIDC token for Sigstore
+		idToken, err := fetchGitHubOIDCToken(ctx, "sigstore")
+		if err != nil {
+			return nil, &SigningError{
+				Type:     ErrorTypeSigstore,
+				Artifact: statement.Subject[0].Name,
+				Message:  fmt.Sprintf("failed to fetch GitHub OIDC token: %v", err),
+				Cause:    err,
+			}
+		}
+
 		// Select Fulcio service from signing config
 		fulcioService, err := root.SelectService(signingConfig.FulcioCertificateAuthorityURLs(), sign.FulcioAPIVersions, time.Now())
 		if err != nil {
@@ -263,8 +276,7 @@ func signProvenanceWithSigstore(ctx context.Context, statement *in_toto.Statemen
 		}
 		bundleOpts.CertificateProvider = sign.NewFulcio(fulcioOpts)
 		bundleOpts.CertificateProviderOptions = &sign.CertificateProviderOptions{
-			// Let sigstore-go automatically handle GitHub OIDC
-			// It will use ACTIONS_ID_TOKEN_REQUEST_TOKEN/URL automatically
+			IDToken: idToken,
 		}
 
 		// Configure Rekor transparency log
@@ -353,4 +365,72 @@ func validateSigstoreEnvironment() error {
 
 	log.Debug("Sigstore environment validation passed")
 	return nil
+}
+
+// fetchGitHubOIDCToken fetches an OIDC token from GitHub Actions for Sigstore.
+// It uses the ACTIONS_ID_TOKEN_REQUEST_TOKEN and ACTIONS_ID_TOKEN_REQUEST_URL
+// environment variables to authenticate and retrieve a JWT token with the specified audience.
+func fetchGitHubOIDCToken(ctx context.Context, audience string) (string, error) {
+	requestURL := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	requestToken := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+
+	if requestURL == "" || requestToken == "" {
+		return "", fmt.Errorf("GitHub OIDC environment not configured")
+	}
+
+	// Parse the request URL
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse ACTIONS_ID_TOKEN_REQUEST_URL: %w", err)
+	}
+
+	// Add the audience parameter
+	q := u.Query()
+	q.Set("audience", audience)
+	u.RawQuery = q.Encode()
+
+	// Create HTTP request with context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", requestToken))
+
+	// Execute request with timeout
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to get OIDC token, status: %d, body: %s",
+			resp.StatusCode, string(bodyBytes))
+	}
+
+	// Parse response
+	var payload struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if payload.Value == "" {
+		return "", fmt.Errorf("received empty token from GitHub OIDC")
+	}
+
+	return payload.Value, nil
+}
+
+// getEnvOrDefault returns environment variable value or default
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/pkg/leeway/signing/attestation.go
+++ b/pkg/leeway/signing/attestation.go
@@ -426,11 +426,3 @@ func fetchGitHubOIDCToken(ctx context.Context, audience string) (string, error) 
 
 	return payload.Value, nil
 }
-
-// getEnvOrDefault returns environment variable value or default
-func getEnvOrDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
-}

--- a/pkg/leeway/signing/attestation_test.go
+++ b/pkg/leeway/signing/attestation_test.go
@@ -1117,7 +1117,7 @@ func TestFetchGitHubOIDCToken(t *testing.T) {
 						t.Error("Missing or invalid Authorization header")
 					}
 					w.WriteHeader(http.StatusOK)
-					json.NewEncoder(w).Encode(map[string]string{"value": "test-token-12345"})
+					_ = json.NewEncoder(w).Encode(map[string]string{"value": "test-token-12345"})
 				}))
 			},
 			audience:    "sigstore",
@@ -1138,7 +1138,7 @@ func TestFetchGitHubOIDCToken(t *testing.T) {
 			mockServer: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusInternalServerError)
-					w.Write([]byte(`{"error": "internal error"}`))
+					_, _ = w.Write([]byte(`{"error": "internal error"}`))
 				}))
 			},
 			audience:      "sigstore",
@@ -1150,7 +1150,7 @@ func TestFetchGitHubOIDCToken(t *testing.T) {
 			mockServer: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
-					json.NewEncoder(w).Encode(map[string]string{"value": ""})
+					_ = json.NewEncoder(w).Encode(map[string]string{"value": ""})
 				}))
 			},
 			audience:      "sigstore",
@@ -1162,7 +1162,7 @@ func TestFetchGitHubOIDCToken(t *testing.T) {
 			mockServer: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
-					w.Write([]byte(`invalid json`))
+					_, _ = w.Write([]byte(`invalid json`))
 				}))
 			},
 			audience:      "sigstore",


### PR DESCRIPTION
## Description
Fixes Sigstore signing failure caused by missing OIDC token provisioning.


Fixes Sigstore signing failure caused by missing OIDC token provisioning.

**Problem:** The `sigstore-go` library requires an explicit JWT token in `CertificateProviderOptions.IDToken`, but Leeway was passing an empty struct, assuming the library would auto-fetch from GitHub Actions environment variables.

**Solution:** Implemented `fetchGitHubOIDCToken()` to explicitly retrieve the OIDC token from GitHub Actions using the `ACTIONS_ID_TOKEN_REQUEST_TOKEN` and `ACTIONS_ID_TOKEN_REQUEST_URL` environment variables with `audience=sigstore`.

**Changes:**
- Added `fetchGitHubOIDCToken()` function to fetch JWT from GitHub OIDC provider
- Updated `signSLSAAttestation()` to call token fetching before Fulcio certificate request
- Added comprehensive unit tests with mock HTTP server
- Added error handling for token fetch failures

## Related Issue(s)

Fixes https://linear.app/ona-team/issue/CLC-1959/create-leeway-signing-command

## How to test

```bash
go test -v ./pkg/leeway/signing/... -run TestFetchGitHubOIDCToken
```

## Documentation

No - Internal Leeway implementation fix, no user-facing documentation changes required.
