### PR TITLE
feat(slsa): add RequireAttestation configuration for strict SLSA verification

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,9 @@ const (
 	// EnvvarSLSASourceURI configures the expected source URI for SLSA verification
 	EnvvarSLSASourceURI = "LEEWAY_SLSA_SOURCE_URI"
 
+	// EnvvarSLSARequireAttestation requires SLSA attestations (missing/invalid → build locally)
+	EnvvarSLSARequireAttestation = "LEEWAY_SLSA_REQUIRE_ATTESTATION"
+
 	// EnvvarEnableInFlightChecksums enables in-flight checksumming of cache artifacts
 	EnvvarEnableInFlightChecksums = "LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS"
 
@@ -120,6 +123,7 @@ variables have an effect on leeway:
     <light_blue>LEEWAY_DEFAULT_CACHE_LEVEL</>  Sets the default cache level for builds. Defaults to "remote".
 <light_blue>LEEWAY_SLSA_CACHE_VERIFICATION</>  Enables SLSA verification for cached artifacts (true/false).
         <light_blue>LEEWAY_SLSA_SOURCE_URI</>  Expected source URI for SLSA verification (github.com/owner/repo).
+<light_blue>LEEWAY_SLSA_REQUIRE_ATTESTATION</>  Require valid attestations; missing/invalid → build locally (true/false).
 <light_blue>LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS</>  Enable checksumming of cache artifacts (true/false).
            <light_blue>LEEWAY_EXPERIMENTAL</>  Enables experimental leeway features and commands.
 `),

--- a/pkg/leeway/cache/remote/s3.go
+++ b/pkg/leeway/cache/remote/s3.go
@@ -442,7 +442,11 @@ func (s *S3Cache) downloadOriginal(ctx context.Context, p cache.Package, version
 // This function tries multiple extensions (.tar.gz, .tar) and their corresponding attestations.
 // Returns nil (not an error) when no suitable artifacts are found to allow graceful fallback to local builds.
 //
-// Future CLI flag consideration: --slsa-require-attestation could set RequireAttestation=true
+// Configuration:
+// RequireAttestation can be set via:
+//   - Environment variable: LEEWAY_SLSA_REQUIRE_ATTESTATION=true
+//   - CLI flag: --slsa-require-attestation
+//   - Workspace config: Automatically enabled when provenance.slsa=true in WORKSPACE.yaml
 func (s *S3Cache) downloadWithSLSAVerification(ctx context.Context, p cache.Package, version, localPath string) error {
 	log.WithFields(log.Fields{
 		"package": p.FullName(),

--- a/pkg/leeway/cache/types.go
+++ b/pkg/leeway/cache/types.go
@@ -4,19 +4,23 @@
 // The cache system supports SLSA (Supply-chain Levels for Software Artifacts) verification
 // for enhanced security. The behavior is controlled by the SLSAConfig.RequireAttestation field:
 //
-//   - RequireAttestation=false (default): Missing attestation → download without verification
-//     This provides graceful degradation and backward compatibility.
+//   - RequireAttestation=false (default): Missing/invalid attestation → download without verification
+//     This provides graceful degradation and backward compatibility. The artifact is downloaded
+//     and used, but a warning is logged about the missing or invalid attestation.
 //
-//   - RequireAttestation=true: Missing attestation → skip download, allow local build fallback
-//     This enforces strict security but may impact build performance.
+//   - RequireAttestation=true: Missing/invalid attestation → skip download, allow local build fallback
+//     This enforces strict security but may impact build performance. When verification fails,
+//     the artifact is not downloaded, forcing a local rebuild with proper attestation.
 //
 // The cache system is designed to never fail builds due to cache issues. When artifacts
 // cannot be downloaded (missing, verification failed, network issues), the system gracefully
 // falls back to local builds.
 //
-// Future Evolution:
-// A CLI flag like --slsa-require-attestation could be added to set RequireAttestation=true
-// for environments that require strict SLSA compliance.
+// Configuration:
+// RequireAttestation can be controlled via:
+// - Environment variable: LEEWAY_SLSA_REQUIRE_ATTESTATION=true
+// - CLI flag: --slsa-require-attestation
+// - Workspace SLSA config: Automatically enabled when provenance.slsa=true in WORKSPACE.yaml
 package cache
 
 import (

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -37,6 +37,9 @@ const (
 	// EnvvarSLSASourceURI configures the expected source URI for SLSA verification
 	EnvvarSLSASourceURI = "LEEWAY_SLSA_SOURCE_URI"
 
+	// EnvvarSLSARequireAttestation requires SLSA attestations (missing/invalid → build locally)
+	EnvvarSLSARequireAttestation = "LEEWAY_SLSA_REQUIRE_ATTESTATION"
+
 	// EnvvarEnableInFlightChecksums enables in-flight checksumming of cache artifacts
 	EnvvarEnableInFlightChecksums = "LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS"
 )
@@ -75,6 +78,7 @@ type WorkspaceProvenance struct {
 //
 // Sets environment variables as defaults (only if not already set):
 // - LEEWAY_SLSA_CACHE_VERIFICATION
+// - LEEWAY_SLSA_REQUIRE_ATTESTATION
 // - LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS
 // - LEEWAY_DOCKER_EXPORT_TO_CACHE
 // - LEEWAY_SLSA_SOURCE_URI (from Git origin)
@@ -90,6 +94,11 @@ func (w *Workspace) ApplySLSADefaults() {
 	// Auto-enable cache verification (global feature)
 	if setEnvDefault(EnvvarSLSACacheVerification, "true") {
 		log.Debug("Auto-enabled: LEEWAY_SLSA_CACHE_VERIFICATION=true")
+	}
+
+	// Auto-enable require attestation for strict SLSA compliance (global feature)
+	if setEnvDefault(EnvvarSLSARequireAttestation, "true") {
+		log.Debug("Auto-enabled: LEEWAY_SLSA_REQUIRE_ATTESTATION=true")
 	}
 
 	// Auto-enable in-flight checksumming (global feature)


### PR DESCRIPTION
## Summary

Adds support for `LEEWAY_SLSA_REQUIRE_ATTESTATION` environment variable and `--slsa-require-attestation` CLI flag to control behavior when SLSA attestations are missing or invalid.

## Problem

When attestations from one PR fail verification in another PR (e.g., due to source URI mismatches like `refs/pull/11265/merge` vs `refs/pull/11279/merge`), the current behavior downloads artifacts without verification. This creates a security gap where unverified artifacts are used without being re-signed with the correct attestation.

Fixes https://linear.app/ona-team/issue/CLC-2053/mechanism-to-control-behavior-when-slsa-attestations-are-missing-or

## Solution

Add `RequireAttestation` configuration that enables two verification modes:

### Permissive Mode (RequireAttestation=false, default)
- Missing/invalid attestation → Download without verification (with warning)
- Provides graceful degradation and backward compatibility
- Useful during migration or when some artifacts lack attestations

### Strict Mode (RequireAttestation=true)
- Missing/invalid attestation → Skip download, build locally with correct attestation
- Enables self-healing for cross-PR attestation mismatches
- Auto-enabled when `provenance.slsa=true` in WORKSPACE.yaml
- Recommended for production environments requiring SLSA L3 compliance

## Changes

### Configuration (Commit 1)
- Add `EnvvarSLSARequireAttestation` constant to `cmd/root.go` and `pkg/leeway/workspace.go`
- Add `--slsa-require-attestation` flag to build command
- Update `parseSLSAConfig()` to read and apply RequireAttestation setting
- Update `ApplySLSADefaults()` to auto-enable RequireAttestation with SLSA L3
- Enhance documentation in `pkg/leeway/cache/types.go`
- Update implementation comments in `pkg/leeway/cache/remote/s3.go`

Note: The actual RequireAttestation logic in `downloadWithSLSAVerification()` was already implemented; this PR adds the configuration mechanism.

### Tests (Commit 2)
- Extend `TestBuildCommandFlags` with 3 test cases for `--slsa-require-attestation` flag
- Add `TestParseSLSAConfig` with 6 test cases for configuration parsing logic
- Tests verify flag parsing, environment variable handling, and CLI flag precedence

### Documentation (Commit 3)
- Add "SLSA Cache Verification Modes" section to README.md
- Add `LEEWAY_SLSA_REQUIRE_ATTESTATION` to CLI help text
- Provide examples for overriding the mode

## Usage

### Via Environment Variable
```bash
export LEEWAY_SLSA_REQUIRE_ATTESTATION=true
leeway build :app
```

### Via CLI Flag
```bash
leeway build :app --slsa-require-attestation
```

### Automatic (Workspace Config)
```yaml
# WORKSPACE.yaml
provenance:
  enabled: true
  slsa: true  # Automatically enables RequireAttestation=true
```

## Testing

All tests pass:
```bash
$ go test ./cmd/... ./pkg/leeway/cache/...
PASS
ok      github.com/gitpod-io/leeway/cmd                         0.761s
ok      github.com/gitpod-io/leeway/pkg/leeway/cache/remote    62.909s
```

## Implementation Notes

- Only affects AWS S3 remote cache (GCP/gsutil does not support SLSA verification)
- The RequireAttestation logic is used in one place: `S3Cache.downloadWithSLSAVerification()` (line 484)
- Existing tests in `s3_slsa_test.go` and `s3_resilience_test.go` already verify the behavior

