### PR TITLE
fix: make gzip compression deterministic

### DIFF
--- a/pkg/leeway/compression.go
+++ b/pkg/leeway/compression.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	compressor   = "gzip"
+	compressor   = "gzip -n"
 	decompressor = "gzip -d"
 	// Number of CPU cores for parallel processing
 	cpuCores = runtime.NumCPU()
@@ -20,7 +20,8 @@ func init() {
 	pigz, err := exec.LookPath("pigz")
 	if err == nil {
 		// Use all available CPU cores by default
-		compressor = fmt.Sprintf("%s -p %d", pigz, cpuCores)
+		// -n flag ensures deterministic output by not storing timestamps
+		compressor = fmt.Sprintf("%s -n -p %d", pigz, cpuCores)
 	}
 }
 
@@ -128,7 +129,8 @@ func getCompressionCommand(algo CompressionAlgorithm, level int) string {
 		return ""
 	default: // Gzip or fallback
 		if level > 0 {
-			return fmt.Sprintf("gzip -%d", level)
+			// -n flag ensures deterministic output by not storing timestamps
+			return fmt.Sprintf("gzip -n -%d", level)
 		}
 		return compressor
 	}


### PR DESCRIPTION
## Problem

Gzip includes timestamps by default, making compression non-deterministic. This causes SLSA attestation verification failures when artifacts are re-compressed or re-uploaded, as the digest changes even with identical content.

### Example of the Issue

```bash
$ echo "test" > file1.txt && sleep 1 && echo "test" > file2.txt
$ gzip -c file1.txt | sha256sum
45e6ddc0b77817816e3334c092fb66579d1d1c3d0ce23a0f5f34de841672cc62

$ gzip -c file2.txt | sha256sum  
0505649d946d01d25321923b415787bf4cb8a5f626bb915bc9c7cd54b0d2335e
# Different digests for identical content!
```

This breaks SLSA verification when:
1. Artifact is built and uploaded with attestation (digest A)
2. Artifact is re-built or re-compressed (digest B)
3. Verification fails because digest B ≠ digest A

## Solution

Add the `-n` flag to all gzip/pigz commands to exclude timestamps from compressed output.

### Changes

- Add `-n` flag to default `gzip` compressor
- Add `-n` flag to `pigz` compressor (parallel gzip)
- Add `-n` flag when custom compression levels are specified

### Verification

```bash
$ gzip -n -c file1.txt | sha256sum && gzip -n -c file2.txt | sha256sum
5d650c41729b3adf7752c8c558f312aff745ed5de2cba79255c5b7866753e635
5d650c41729b3adf7752c8c558f312aff745ed5de2cba79255c5b7866753e635
# Identical digests! ✅
```

## Benefits

- ✅ **Deterministic builds:** Same content always produces same digest
- ✅ **SLSA compliance:** Attestations remain valid across re-uploads
- ✅ **Reproducible builds:** Aligns with SLSA best practices
- ✅ **Cache reliability:** Prevents false cache misses from timestamp differences

## Testing

- All existing tests pass
- Verified deterministic compression behavior
- No breaking changes to API or behavior

## Related

This fix is particularly important for the `sign-cache` workflow where artifacts may be re-uploaded after attestation creation, causing digest mismatches during verification.

Part of https://linear.app/ona-team/issue/CLC-2062/ensure-leeway-does-not-uploads-again-cache-artifact