### PR TITLE
fix: avoid re-uploading downloaded artifacts in sign-cache

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -414,6 +414,10 @@ func (c *pushOnlyRemoteCache) UploadFile(ctx context.Context, filePath string, k
 	return c.C.UploadFile(ctx, filePath, key)
 }
 
+func (c *pushOnlyRemoteCache) HasFile(ctx context.Context, key string) (bool, error) {
+	return c.C.HasFile(ctx, key)
+}
+
 type pullOnlyRemoteCache struct {
 	C cache.RemoteCache
 }
@@ -432,6 +436,10 @@ func (c *pullOnlyRemoteCache) Upload(ctx context.Context, src cache.LocalCache, 
 
 func (c *pullOnlyRemoteCache) UploadFile(ctx context.Context, filePath string, key string) error {
 	return nil
+}
+
+func (c *pullOnlyRemoteCache) HasFile(ctx context.Context, key string) (bool, error) {
+	return c.C.HasFile(ctx, key)
 }
 
 func getRemoteCacheFromEnv() cache.RemoteCache {

--- a/pkg/leeway/cache/remote/no_cache.go
+++ b/pkg/leeway/cache/remote/no_cache.go
@@ -33,3 +33,8 @@ func (NoRemoteCache) Upload(ctx context.Context, src cache.LocalCache, pkgs []ca
 func (NoRemoteCache) UploadFile(ctx context.Context, filePath string, key string) error {
 	return nil
 }
+
+// HasFile checks if a file exists in the remote cache with the given key
+func (NoRemoteCache) HasFile(ctx context.Context, key string) (bool, error) {
+	return false, nil
+}

--- a/pkg/leeway/cache/types.go
+++ b/pkg/leeway/cache/types.go
@@ -56,6 +56,10 @@ type RemoteCache interface {
 	// UploadFile uploads a single file to the remote cache with the given key
 	// This is useful for uploading individual files like attestations without Package abstraction
 	UploadFile(ctx context.Context, filePath string, key string) error
+
+	// HasFile checks if a file exists in the remote cache with the given key
+	// This is useful for checking if artifacts need to be uploaded
+	HasFile(ctx context.Context, key string) (bool, error)
 }
 
 // ObjectStorage represents a generic object storage interface

--- a/pkg/leeway/signing/attestation_test.go
+++ b/pkg/leeway/signing/attestation_test.go
@@ -914,6 +914,10 @@ func (m *mockRemoteCache) UploadFile(ctx context.Context, filePath string, key s
 	return nil
 }
 
+func (m *mockRemoteCache) HasFile(ctx context.Context, key string) (bool, error) {
+	return false, nil
+}
+
 // TestGetEnvOrDefault tests the environment variable helper
 // TestValidateSigstoreEnvironment tests Sigstore environment validation
 func TestValidateSigstoreEnvironment(t *testing.T) {


### PR DESCRIPTION
## Problem

The `sign-cache` command was re-uploading ALL artifacts to the remote cache, including those that were already present (downloaded from cache). This caused several issues:

1. **Unnecessary network traffic and storage costs** - Re-uploading artifacts that already exist
2. **Potential digest mismatches** - If artifacts are re-compressed with different timestamps (see #262)
3. **Overwrites existing artifacts** - Downloaded artifacts get re-uploaded, potentially with different content

### Current Behavior

```
Build Job:
  1. Build artifact → Upload to S3 (digest A)

Sign Job:
  2. Download artifact from S3 (digest A)
  3. Create attestation (digest A)
  4. Re-upload artifact to S3 (digest A) ← Unnecessary!
  5. Upload attestation
```

### Expected Behavior (SLSA L3)

```
Build Job:
  1. Build artifact (no upload)

Sign & Upload Job:
  2. Create attestation
  3. Upload ONLY locally built artifacts
  4. Skip downloaded artifacts (already in S3)
  5. Upload attestation
```

## Solution

Add a `HasFile()` method to the `RemoteCache` interface to check if an artifact already exists before uploading. The `sign-cache` command now:

- ✅ Checks if artifact exists in remote cache
- ✅ Skips upload if it already exists (downloaded artifacts)
- ✅ Uploads only new artifacts (locally built)
- ✅ Always uploads attestation files (they're new)

This aligns with the `build` command behavior, which only uploads newly built packages via `GetNewPackagesForCache()`.

## Changes

### Core Changes
- Add `HasFile(ctx, key)` method to `RemoteCache` interface
- Implement `HasFile()` in:
  - `S3Cache` - uses `storage.HasObject()`
  - `GSUtilCache` - uses `gsutil stat`
  - `NoRemoteCache` - returns `false`
- Update `UploadArtifactWithAttestation()` to check before uploading artifacts

### Supporting Changes
- Update wrapper types (`pushOnlyRemoteCache`, `pullOnlyRemoteCache`) to implement `HasFile()`
- Add comprehensive tests for skip/upload behavior
- Update mock implementations in tests

## Testing

### New Tests
- `TestArtifactUploader_SkipsExistingArtifacts` - Verifies existing artifacts are not re-uploaded
- `TestArtifactUploader_UploadsNewArtifacts` - Verifies new artifacts are uploaded

### Test Results
```bash
$ go test ./pkg/leeway/signing/... -v
✅ All tests pass
```

## Benefits

- ✅ **Prevents re-uploading downloaded artifacts** - Saves bandwidth and storage
- ✅ **Reduces network traffic and costs** - Only uploads what's needed
- ✅ **Avoids potential digest mismatches** - No re-compression of existing artifacts
- ✅ **Maintains SLSA attestation integrity** - Artifacts match their attestations
- ✅ **Aligns with build command behavior** - Consistent upload logic

## Example Log Output

### Before (Re-uploads everything)
```
INFO Successfully uploaded artifact to remote cache artifact=existing.tar.gz
INFO Successfully uploaded attestation file artifact=existing.tar.gz
```

### After (Skips existing)
```
INFO Artifact already exists in remote cache, skipping upload artifact=existing.tar.gz
INFO Successfully uploaded attestation file artifact=existing.tar.gz
```

## Related

- Complements #262 (deterministic gzip compression)
- Fixes the root cause of unnecessary artifact re-uploads
- Enables proper SLSA L3 workflow separation
- Fixes Part of https://linear.app/ona-team/issue/CLC-2062/ensure-leeway-does-not-uploads-again-cache-artifact