### PR TITLE
fix(build): correct total count in build summary

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -768,7 +768,7 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 }
 
 // printBuildSummary prints a summary of the build showing what was cached, downloaded, and built
-func printBuildSummary(ctx *buildContext, targetPkg *Package, allpkg []*Package, initialStatus map[*Package]PackageBuildStatus, pkgsToDownload []*Package) {
+func printBuildSummary(ctx *buildContext, targetPkg *Package, allpkg []*Package, statusAfterDownload map[*Package]PackageBuildStatus, pkgsToDownload []*Package) {
 	var (
 		builtLocally  int
 		downloaded    int
@@ -808,13 +808,13 @@ func printBuildSummary(ctx *buildContext, targetPkg *Package, allpkg []*Package,
 			
 			// Check if this was supposed to be downloaded but wasn't
 			// This indicates verification or download failure
-			if pkgsToDownloadMap[p.FullName()] && initialStatus[p] != PackageDownloaded {
+			if pkgsToDownloadMap[p.FullName()] && statusAfterDownload[p] != PackageDownloaded {
 				failedDownloads = append(failedDownloads, p)
 			}
-		} else if initialStatus[p] == PackageDownloaded {
+		} else if statusAfterDownload[p] == PackageDownloaded {
 			// Package was downloaded
 			downloaded++
-		} else if initialStatus[p] == PackageBuilt {
+		} else if statusAfterDownload[p] == PackageBuilt {
 			// Package was already cached
 			alreadyCached++
 		} else {

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -791,8 +791,6 @@ func printBuildSummary(ctx *buildContext, targetPkg *Package, allpkg []*Package,
 	}
 
 	for _, p := range allpkg {
-		total++
-		
 		// Check actual state in local cache
 		_, inCache := ctx.LocalCache.Location(p)
 		
@@ -800,6 +798,8 @@ func printBuildSummary(ctx *buildContext, targetPkg *Package, allpkg []*Package,
 			// Package not in cache (shouldn't happen if build succeeded)
 			continue
 		}
+		
+		total++
 
 		// Determine what happened to this package
 		if newlyBuiltMap[p.FullName()] {


### PR DESCRIPTION
## Summary

Fixes an accounting bug in the build summary where `total` would not match the sum of categorized packages.

## Problem

In `printBuildSummary`, the `total` counter was incremented for all packages in `allpkg`, but packages not in cache were skipped with `continue`. This caused:

```
total != (builtLocally + downloaded + alreadyCached)
```

## Fix

Move `total++` to **after** the cache check, so we only count packages that are actually in the cache and being categorized.

## Impact

- Build summary totals are now accurate
- No functional changes to build behavior
- Small, focused fix to PR #273

## Related

Follow-up to #273 which was just merged.