### PR TITLE
feat(sign-cache): increase default concurrency and add configurability

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,9 @@ const (
 
 	// EnvvarExperimental enables experimental features
 	EnvvarExperimental = "LEEWAY_EXPERIMENTAL"
+
+	// EnvvarMaxSigningConcurrency configures maximum concurrent signing operations
+	EnvvarMaxSigningConcurrency = "LEEWAY_MAX_SIGNING_CONCURRENCY"
 )
 
 const (


### PR DESCRIPTION
## Summary

Increases default signing concurrency from 5 to 20 concurrent operations to better utilize network I/O for Sigstore API calls, providing ~4x faster signing for typical workloads.

Fixes https://linear.app/ona-team/issue/CLC-2084/improve-the-performance-of-attestation-signing-with-configurable

## Changes

- **Increase default concurrency**: 5 → 20 (4x improvement)
- **Add `--max-signing-concurrency` flag**: Runtime configuration (default: 20)
- **Add `LEEWAY_MAX_SIGNING_CONCURRENCY` env var**: Environment-based configuration
- **Proper precedence**: Env var sets default, explicit flag overrides (follows Leeway pattern)
- **Automatic validation**: Bounds checking (1-100 range) with warning logs
- **Comprehensive tests**: Env var/flag precedence and validation coverage
- **Enhanced documentation**: Help text with concurrency section and examples
- **Code cleanup**: Removed unused `cmd` parameter from `runSignCache`

## Performance Impact

- **Current**: 100 artifacts ÷ 5 = 20 batches × 3s = ~60 seconds
- **Optimized**: 100 artifacts ÷ 20 = 5 batches × 3s = ~15 seconds
- **Gain**: ~4x faster signing for typical workloads
- **Configurable**: Can be tuned up to 100 for high-throughput scenarios

## Implementation Details

Follows existing Leeway patterns:
- Environment variable handling uses `cmd.Flags().Changed()` pattern (same as `in-flight-checksums`)
- Naming convention follows `LEEWAY_*` pattern
- Structured logging with `log.WithField()`
- Test patterns match existing test suites

## Testing

All tests pass:
- ✅ `TestMaxSigningConcurrencyEnvironmentVariable` - 8 test cases for env var/flag precedence
- ✅ `TestMaxSigningConcurrencyValidation` - 6 test cases for bounds validation
- ✅ All existing `sign-cache` tests continue to pass
- ✅ Full test suite: `go test ./... -short`

## Examples

```bash
# Use default (20)
leeway plumbing sign-cache --from-manifest artifacts.txt

# Override with flag
leeway plumbing sign-cache --from-manifest artifacts.txt --max-signing-concurrency 30

# Override with env var
LEEWAY_MAX_SIGNING_CONCURRENCY=30 leeway plumbing sign-cache --from-manifest artifacts.txt

# Flag takes precedence over env var
LEEWAY_MAX_SIGNING_CONCURRENCY=10 leeway plumbing sign-cache --from-manifest artifacts.txt --max-signing-concurrency 40
```