### PR TITLE
feat(sbom): normalize SBOMs for deterministic builds

### DIFF
--- a/pkg/leeway/sbom_normalize_test.go
+++ b/pkg/leeway/sbom_normalize_test.go
@@ -1,0 +1,487 @@
+package leeway
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestGenerateDeterministicUUID(t *testing.T) {
+	tests := []struct {
+		name     string
+		content1 []byte
+		content2 []byte
+		wantSame bool
+	}{
+		{
+			name:     "identical content produces same UUID",
+			content1: []byte("test content"),
+			content2: []byte("test content"),
+			wantSame: true,
+		},
+		{
+			name:     "different content produces different UUID",
+			content1: []byte("test content 1"),
+			content2: []byte("test content 2"),
+			wantSame: false,
+		},
+		{
+			name:     "empty content is deterministic",
+			content1: []byte(""),
+			content2: []byte(""),
+			wantSame: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uuid1 := generateDeterministicUUID(tt.content1)
+			uuid2 := generateDeterministicUUID(tt.content2)
+
+			if tt.wantSame && uuid1 != uuid2 {
+				t.Errorf("expected same UUID for identical content, got %s and %s", uuid1, uuid2)
+			}
+			if !tt.wantSame && uuid1 == uuid2 {
+				t.Errorf("expected different UUIDs for different content, got %s", uuid1)
+			}
+
+			// Verify UUID format (8-4-4-4-12 hex digits)
+			if len(uuid1) != 36 {
+				t.Errorf("expected UUID length 36, got %d", len(uuid1))
+			}
+			
+			// Verify UUID format matches pattern: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			uuidPattern := `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
+			matched, err := regexp.MatchString(uuidPattern, uuid1)
+			if err != nil {
+				t.Fatalf("failed to compile UUID pattern: %v", err)
+			}
+			if !matched {
+				t.Errorf("UUID does not match expected format: %s", uuid1)
+			}
+		})
+	}
+}
+
+func TestGetGitCommitTimestamp_SourceDateEpoch(t *testing.T) {
+	// Save original env var
+	originalEnv := os.Getenv("SOURCE_DATE_EPOCH")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("SOURCE_DATE_EPOCH", originalEnv)
+		} else {
+			os.Unsetenv("SOURCE_DATE_EPOCH")
+		}
+	}()
+
+	tests := []struct {
+		name          string
+		sourceEpoch   string
+		wantTimestamp time.Time
+		wantErr       bool
+	}{
+		{
+			name:          "valid SOURCE_DATE_EPOCH",
+			sourceEpoch:   "1234567890",
+			wantTimestamp: time.Unix(1234567890, 0).UTC(),
+			wantErr:       false,
+		},
+		{
+			name:        "invalid SOURCE_DATE_EPOCH falls back to git",
+			sourceEpoch: "invalid",
+			wantErr:     false, // Should fall back to git (may fail if not in git repo)
+		},
+		{
+			name:        "empty SOURCE_DATE_EPOCH uses git",
+			sourceEpoch: "",
+			wantErr:     false, // Should use git (may fail if not in git repo)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.sourceEpoch != "" {
+				os.Setenv("SOURCE_DATE_EPOCH", tt.sourceEpoch)
+			} else {
+				os.Unsetenv("SOURCE_DATE_EPOCH")
+			}
+
+			// Use HEAD as commit (should exist in test environment)
+			timestamp, err := getGitCommitTimestamp("HEAD")
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil && tt.sourceEpoch == "1234567890" {
+				// Only fail if we expected success with valid SOURCE_DATE_EPOCH
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tt.sourceEpoch == "1234567890" && !timestamp.Equal(tt.wantTimestamp) {
+				t.Errorf("expected timestamp %v, got %v", tt.wantTimestamp, timestamp)
+			}
+		})
+	}
+}
+
+func TestGetGitCommitTimestamp_GitCommit(t *testing.T) {
+	// This test requires being in a git repository
+	// Use HEAD as a known commit
+	timestamp, err := getGitCommitTimestamp("HEAD")
+	if err != nil {
+		t.Skipf("skipping test: not in a git repository or git not available: %v", err)
+	}
+
+	// Verify timestamp is reasonable (after 2020, before 2100)
+	if timestamp.Year() < 2020 || timestamp.Year() > 2100 {
+		t.Errorf("unexpected timestamp year: %d", timestamp.Year())
+	}
+
+	// Verify timestamp is in UTC
+	if timestamp.Location() != time.UTC {
+		t.Errorf("expected UTC timezone, got %v", timestamp.Location())
+	}
+
+	// Verify deterministic: calling twice should return same result
+	timestamp2, err := getGitCommitTimestamp("HEAD")
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+	if !timestamp.Equal(timestamp2) {
+		t.Errorf("expected deterministic result, got %v and %v", timestamp, timestamp2)
+	}
+}
+
+func TestNormalizeCycloneDX(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	sbomPath := filepath.Join(tmpDir, "sbom.cdx.json")
+
+	// Create a sample CycloneDX SBOM
+	sbom := map[string]interface{}{
+		"bomFormat":    "CycloneDX",
+		"specVersion":  "1.4",
+		"serialNumber": "urn:uuid:original-uuid-12345",
+		"metadata": map[string]interface{}{
+			"timestamp": "2023-01-01T00:00:00Z",
+			"component": map[string]interface{}{
+				"name": "test-component",
+			},
+		},
+		"components": []interface{}{
+			map[string]interface{}{
+				"name":    "test-package",
+				"version": "1.0.0",
+			},
+		},
+	}
+
+	// Write initial SBOM
+	data, err := json.MarshalIndent(sbom, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal test SBOM: %v", err)
+	}
+	if err := os.WriteFile(sbomPath, data, 0644); err != nil {
+		t.Fatalf("failed to write test SBOM: %v", err)
+	}
+
+	// Normalize with a fixed timestamp
+	fixedTime := time.Unix(1234567890, 0).UTC()
+	if err := normalizeCycloneDX(sbomPath, fixedTime); err != nil {
+		t.Fatalf("normalizeCycloneDX failed: %v", err)
+	}
+
+	// Read normalized SBOM
+	normalizedData, err := os.ReadFile(sbomPath)
+	if err != nil {
+		t.Fatalf("failed to read normalized SBOM: %v", err)
+	}
+
+	var normalizedSBOM map[string]interface{}
+	if err := json.Unmarshal(normalizedData, &normalizedSBOM); err != nil {
+		t.Fatalf("failed to parse normalized SBOM: %v", err)
+	}
+
+	// Verify timestamp was updated
+	metadata := normalizedSBOM["metadata"].(map[string]interface{})
+	timestamp := metadata["timestamp"].(string)
+	expectedTimestamp := fixedTime.Format(time.RFC3339)
+	if timestamp != expectedTimestamp {
+		t.Errorf("expected timestamp %s, got %s", expectedTimestamp, timestamp)
+	}
+
+	// Verify UUID was changed and is deterministic
+	serialNumber := normalizedSBOM["serialNumber"].(string)
+	if serialNumber == "urn:uuid:original-uuid-12345" {
+		t.Error("UUID was not changed")
+	}
+	if len(serialNumber) < 10 {
+		t.Errorf("invalid UUID format: %s", serialNumber)
+	}
+
+	// Normalize again with same timestamp - should produce same UUID
+	if err := normalizeCycloneDX(sbomPath, fixedTime); err != nil {
+		t.Fatalf("second normalizeCycloneDX failed: %v", err)
+	}
+
+	normalizedData2, err := os.ReadFile(sbomPath)
+	if err != nil {
+		t.Fatalf("failed to read normalized SBOM (2nd time): %v", err)
+	}
+
+	var normalizedSBOM2 map[string]interface{}
+	if err := json.Unmarshal(normalizedData2, &normalizedSBOM2); err != nil {
+		t.Fatalf("failed to parse normalized SBOM (2nd time): %v", err)
+	}
+
+	serialNumber2 := normalizedSBOM2["serialNumber"].(string)
+	if serialNumber != serialNumber2 {
+		t.Errorf("expected deterministic UUID, got %s and %s", serialNumber, serialNumber2)
+	}
+}
+
+func TestNormalizeSPDX(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	sbomPath := filepath.Join(tmpDir, "sbom.spdx.json")
+
+	// Create a sample SPDX SBOM
+	sbom := map[string]interface{}{
+		"spdxVersion":       "SPDX-2.3",
+		"dataLicense":       "CC0-1.0",
+		"SPDXID":            "SPDXRef-DOCUMENT",
+		"name":              "test-sbom",
+		"documentNamespace": "https://example.com/test-12345678-1234-1234-1234-123456789abc",
+		"creationInfo": map[string]interface{}{
+			"created": "2023-01-01T00:00:00Z",
+			"creators": []interface{}{
+				"Tool: test-tool",
+			},
+		},
+		"packages": []interface{}{
+			map[string]interface{}{
+				"SPDXID":  "SPDXRef-Package",
+				"name":    "test-package",
+				"version": "1.0.0",
+			},
+		},
+	}
+
+	// Write initial SBOM
+	data, err := json.MarshalIndent(sbom, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal test SBOM: %v", err)
+	}
+	if err := os.WriteFile(sbomPath, data, 0644); err != nil {
+		t.Fatalf("failed to write test SBOM: %v", err)
+	}
+
+	// Normalize with a fixed timestamp
+	fixedTime := time.Unix(1234567890, 0).UTC()
+	if err := normalizeSPDX(sbomPath, fixedTime); err != nil {
+		t.Fatalf("normalizeSPDX failed: %v", err)
+	}
+
+	// Read normalized SBOM
+	normalizedData, err := os.ReadFile(sbomPath)
+	if err != nil {
+		t.Fatalf("failed to read normalized SBOM: %v", err)
+	}
+
+	var normalizedSBOM map[string]interface{}
+	if err := json.Unmarshal(normalizedData, &normalizedSBOM); err != nil {
+		t.Fatalf("failed to parse normalized SBOM: %v", err)
+	}
+
+	// Verify timestamp was updated
+	creationInfo := normalizedSBOM["creationInfo"].(map[string]interface{})
+	created := creationInfo["created"].(string)
+	expectedTimestamp := fixedTime.Format(time.RFC3339)
+	if created != expectedTimestamp {
+		t.Errorf("expected timestamp %s, got %s", expectedTimestamp, created)
+	}
+
+	// Verify UUID in documentNamespace was changed
+	namespace := normalizedSBOM["documentNamespace"].(string)
+	if namespace == "https://example.com/test-12345678-1234-1234-1234-123456789abc" {
+		t.Error("UUID in documentNamespace was not changed")
+	}
+
+	// Normalize again with same timestamp - should produce same UUID
+	if err := normalizeSPDX(sbomPath, fixedTime); err != nil {
+		t.Fatalf("second normalizeSPDX failed: %v", err)
+	}
+
+	normalizedData2, err := os.ReadFile(sbomPath)
+	if err != nil {
+		t.Fatalf("failed to read normalized SBOM (2nd time): %v", err)
+	}
+
+	var normalizedSBOM2 map[string]interface{}
+	if err := json.Unmarshal(normalizedData2, &normalizedSBOM2); err != nil {
+		t.Fatalf("failed to parse normalized SBOM (2nd time): %v", err)
+	}
+
+	namespace2 := normalizedSBOM2["documentNamespace"].(string)
+	if namespace != namespace2 {
+		t.Errorf("expected deterministic UUID, got %s and %s", namespace, namespace2)
+	}
+}
+
+func TestNormalizeCycloneDX_MalformedSBOM(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		sbomContent string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid JSON",
+			sbomContent: `{invalid json}`,
+			wantErr:     true,
+			errContains: "failed to parse SBOM",
+		},
+		{
+			name:        "missing metadata field",
+			sbomContent: `{"bomFormat": "CycloneDX", "specVersion": "1.4"}`,
+			wantErr:     true,
+			errContains: "metadata field not found",
+		},
+		{
+			name:        "empty file",
+			sbomContent: ``,
+			wantErr:     true,
+			errContains: "failed to parse SBOM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbomPath := filepath.Join(tmpDir, "test-"+tt.name+".json")
+			if err := os.WriteFile(sbomPath, []byte(tt.sbomContent), 0644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+
+			fixedTime := time.Unix(1234567890, 0).UTC()
+			err := normalizeCycloneDX(sbomPath, fixedTime)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeSPDX_MalformedSBOM(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		sbomContent string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid JSON",
+			sbomContent: `{invalid json}`,
+			wantErr:     true,
+			errContains: "failed to parse SBOM",
+		},
+		{
+			name:        "missing creationInfo field",
+			sbomContent: `{"spdxVersion": "SPDX-2.3", "name": "test"}`,
+			wantErr:     true,
+			errContains: "creationInfo field not found",
+		},
+		{
+			name:        "empty file",
+			sbomContent: ``,
+			wantErr:     true,
+			errContains: "failed to parse SBOM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbomPath := filepath.Join(tmpDir, "test-"+tt.name+".json")
+			if err := os.WriteFile(sbomPath, []byte(tt.sbomContent), 0644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+
+			fixedTime := time.Unix(1234567890, 0).UTC()
+			err := normalizeSPDX(sbomPath, fixedTime)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeCycloneDX_FileErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("non-existent file", func(t *testing.T) {
+		sbomPath := filepath.Join(tmpDir, "nonexistent.json")
+		fixedTime := time.Unix(1234567890, 0).UTC()
+		err := normalizeCycloneDX(sbomPath, fixedTime)
+		if err == nil {
+			t.Error("expected error for non-existent file, got nil")
+		}
+		if !contains(err.Error(), "failed to read SBOM") {
+			t.Errorf("expected 'failed to read SBOM' error, got: %v", err)
+		}
+	})
+}
+
+func TestNormalizeSPDX_FileErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("non-existent file", func(t *testing.T) {
+		sbomPath := filepath.Join(tmpDir, "nonexistent.json")
+		fixedTime := time.Unix(1234567890, 0).UTC()
+		err := normalizeSPDX(sbomPath, fixedTime)
+		if err == nil {
+			t.Error("expected error for non-existent file, got nil")
+		}
+		if !contains(err.Error(), "failed to read SBOM") {
+			t.Errorf("expected 'failed to read SBOM' error, got: %v", err)
+		}
+	})
+}
+
+// contains is a helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Overview

Makes SBOM generation deterministic by normalizing timestamps and UUIDs after Syft generates them. This enables reproducible builds where the same source produces the same artifact SHA256.

Part of https://linear.app/ona-team/issue/CLC-2096/prevent-attestation-overwrites-in-concurrent-builds
Part of https://linear.app/ona-team/issue/CLC-2097/improve-builds-determinism

## Changes

### Implementation (`pkg/leeway/sbom.go`)

1. **`getGitCommitTimestamp()`**: Retrieves deterministic timestamp from git commit
   - Respects `SOURCE_DATE_EPOCH` environment variable for reproducible builds
   - Falls back to git commit timestamp
   - Logs warning if `SOURCE_DATE_EPOCH` is invalid

2. **`generateDeterministicUUID()`**: Generates UUIDv5 from content
   - Uses RFC 4122 DNS namespace UUID
   - SHA-1 based for determinism

3. **`normalizeCycloneDX()`**: Normalizes CycloneDX SBOM
   - Replaces timestamp with git commit time
   - Generates deterministic UUID from content

4. **`normalizeSPDX()`**: Normalizes SPDX SBOM
   - Replaces timestamp with git commit time
   - Generates deterministic UUID in documentNamespace

5. **Updated `writeSBOM()`**: Calls normalizers after SBOM generation
   - Fails fast if deterministic timestamp cannot be obtained
   - Provides clear error message with troubleshooting hints

### Tests (`pkg/leeway/sbom_normalize_test.go`)

Comprehensive test coverage including:
- UUID generation (determinism, format validation)
- Git commit timestamp (SOURCE_DATE_EPOCH, git fallback)
- CycloneDX normalization (happy path, malformed input, file errors)
- SPDX normalization (happy path, malformed input, file errors)

## Why These Changes

### Problem
SBOMs contained non-deterministic fields:
- Current timestamp (changes on every build)
- Random UUIDs (different on every build)

This prevented:
- Reproducible builds (same source → different artifact hash)
- Reliable caching
- Attestation verification

### Solution
Post-process SBOMs after Syft generates them to replace non-deterministic values with deterministic ones based on git commit metadata.

### Why Not Wait for Upstream?
- Syft has an [open PR](https://github.com/anchore/syft/pull/3932) for this feature, but it's not merged yet
- Our post-processing approach works with any Syft version
- Both approaches are compatible (we can remove normalization once Syft supports it natively)

## Format-Specific Behavior

- **CycloneDX**: Normalized (has timestamps and UUIDs)
- **SPDX**: Normalized (has timestamps and UUIDs)
- **Syft JSON**: No normalization needed (naturally deterministic - no timestamp field, no random UUIDs)

See [anchore/syft#3931](https://github.com/anchore/syft/issues/3931) for upstream discussion.

## Testing

### Unit Tests
```bash
go test -v ./pkg/leeway -run "TestGenerateDeterministicUUID|TestGetGitCommitTimestamp|TestNormalizeCycloneDX|TestNormalizeSPDX"
```

All tests pass with coverage for normal operation and error conditions.

### Manual Verification
```bash
# Build twice from scratch
rm -rf /tmp/leeway-cache
leeway build //:helloworld -Dversion=test1 --save /tmp/build1.tar.gz

rm -rf /tmp/leeway-cache
leeway build //:helloworld -Dversion=test1 --save /tmp/build2.tar.gz

# Verify SBOMs are identical
tar -xzf /tmp/build1.tar.gz ./sbom.cdx.json && mv sbom.cdx.json sbom1.cdx.json
tar -xzf /tmp/build2.tar.gz ./sbom.cdx.json && mv sbom.cdx.json sbom2.cdx.json
diff sbom1.cdx.json sbom2.cdx.json  # No differences

# Verify timestamp uses git commit time
cat sbom1.cdx.json | jq '.metadata.timestamp'
# Output: "2025-11-17T09:11:11Z" (matches git commit timestamp)

# Verify UUIDs are deterministic
cat sbom1.cdx.json | jq '.serialNumber'
cat sbom2.cdx.json | jq '.serialNumber'
# Both output: "urn:uuid:7cfdf9a9-1f08-55b0-9fbb-23cee00912fe"
```

## Error Handling

Fails fast with clear error message if deterministic timestamp cannot be obtained:
```
failed to get deterministic timestamp for SBOM normalization (commit: abc123): failed to get commit timestamp: ...
Ensure git is available and the repository is not a shallow clone, or set SOURCE_DATE_EPOCH environment variable
```

## Breaking Changes

None. This is a non-breaking enhancement that makes builds more deterministic.


Co-authored-by: Ona <no-reply@ona.com>