### PR TITLE
feat(tar): add deterministic mtime for tar archives

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -2402,7 +2402,7 @@ func createDockerExportMetadata(wd, version string, cfg DockerPkgConfig) error {
 // getDeterministicMtime returns the Unix timestamp to use for tar --mtime flag.
 // It uses the same timestamp source as SBOM normalization for consistency.
 func (p *Package) getDeterministicMtime() (int64, error) {
-	timestamp, err := getGitCommitTimestamp(p.C.Git().Commit)
+	timestamp, err := getGitCommitTimestamp(context.Background(), p.C.Git().Commit)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get deterministic timestamp for tar mtime (commit: %s): %w. "+
 			"Ensure git is available and the repository is not a shallow clone, or set SOURCE_DATE_EPOCH environment variable",

--- a/pkg/leeway/compression.go
+++ b/pkg/leeway/compression.go
@@ -59,6 +59,9 @@ type TarOptions struct {
 
 	// ExcludePatterns specifies patterns to exclude
 	ExcludePatterns []string
+
+	// Mtime sets a deterministic modification time for all files in the archive (Unix timestamp)
+	Mtime int64
 }
 
 // WithOutputFile sets the output file path for the tar archive
@@ -114,6 +117,13 @@ func WithFilesFrom(filePath string) func(*TarOptions) {
 func WithExcludePatterns(patterns ...string) func(*TarOptions) {
 	return func(opts *TarOptions) {
 		opts.ExcludePatterns = append(opts.ExcludePatterns, patterns...)
+	}
+}
+
+// WithMtime sets a deterministic modification time for all files in the archive
+func WithMtime(timestamp int64) func(*TarOptions) {
+	return func(opts *TarOptions) {
+		opts.Mtime = timestamp
 	}
 }
 
@@ -183,6 +193,11 @@ func BuildTarCommand(options ...func(*TarOptions)) []string {
 	// Add Linux-specific optimizations
 	if runtime.GOOS == "linux" {
 		cmd = append(cmd, "--sparse")
+	}
+
+	// Add deterministic mtime if specified
+	if opts.Mtime != 0 {
+		cmd = append(cmd, fmt.Sprintf("--mtime=@%d", opts.Mtime))
 	}
 
 	// Handle files-from case specially

--- a/pkg/leeway/compression_test.go
+++ b/pkg/leeway/compression_test.go
@@ -1,6 +1,7 @@
 package leeway
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -161,5 +162,33 @@ func TestBuildTarCommand_MtimeWithOtherOptions(t *testing.T) {
 		if !strings.Contains(cmdStr, elem) {
 			t.Errorf("BuildTarCommand() missing expected element: %s\nFull command: %s", elem, cmdStr)
 		}
+	}
+}
+
+func TestIsTestEnvironment(t *testing.T) {
+	// This test itself should be detected as a test environment
+	if !isTestEnvironment() {
+		t.Error("isTestEnvironment() should return true when running in test binary")
+	}
+	
+	// Test with explicit environment variable
+	originalEnv := os.Getenv("LEEWAY_TEST_MODE")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("LEEWAY_TEST_MODE", originalEnv)
+		} else {
+			os.Unsetenv("LEEWAY_TEST_MODE")
+		}
+	}()
+	
+	os.Setenv("LEEWAY_TEST_MODE", "true")
+	if !isTestEnvironment() {
+		t.Error("isTestEnvironment() should return true when LEEWAY_TEST_MODE=true")
+	}
+	
+	os.Setenv("LEEWAY_TEST_MODE", "false")
+	// Should still be true because we're in a test binary
+	if !isTestEnvironment() {
+		t.Error("isTestEnvironment() should return true when running in test binary (even if LEEWAY_TEST_MODE=false)")
 	}
 }

--- a/pkg/leeway/compression_test.go
+++ b/pkg/leeway/compression_test.go
@@ -1,0 +1,165 @@
+package leeway
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWithMtime(t *testing.T) {
+	tests := []struct {
+		name      string
+		mtime     int64
+		wantMtime int64
+	}{
+		{
+			name:      "positive timestamp",
+			mtime:     1234567890,
+			wantMtime: 1234567890,
+		},
+		{
+			name:      "zero timestamp",
+			mtime:     0,
+			wantMtime: 0,
+		},
+		{
+			name:      "recent timestamp",
+			mtime:     1700000000,
+			wantMtime: 1700000000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &TarOptions{}
+			WithMtime(tt.mtime)(opts)
+
+			if opts.Mtime != tt.wantMtime {
+				t.Errorf("WithMtime() set Mtime = %d, want %d", opts.Mtime, tt.wantMtime)
+			}
+		})
+	}
+}
+
+func TestBuildTarCommand_WithMtime(t *testing.T) {
+	tests := []struct {
+		name          string
+		mtime         int64
+		wantMtimeFlag bool
+		wantFlag      string
+	}{
+		{
+			name:          "with mtime set",
+			mtime:         1234567890,
+			wantMtimeFlag: true,
+			wantFlag:      "--mtime=@1234567890",
+		},
+		{
+			name:          "with zero mtime (not set)",
+			mtime:         0,
+			wantMtimeFlag: false,
+			wantFlag:      "",
+		},
+		{
+			name:          "with recent mtime",
+			mtime:         1700000000,
+			wantMtimeFlag: true,
+			wantFlag:      "--mtime=@1700000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cmd []string
+			if tt.mtime != 0 {
+				cmd = BuildTarCommand(
+					WithOutputFile("test.tar.gz"),
+					WithMtime(tt.mtime),
+				)
+			} else {
+				cmd = BuildTarCommand(
+					WithOutputFile("test.tar.gz"),
+				)
+			}
+
+			// Check if --mtime flag is present
+			hasMtimeFlag := false
+			for _, arg := range cmd {
+				if strings.HasPrefix(arg, "--mtime=") {
+					hasMtimeFlag = true
+					if tt.wantMtimeFlag && arg != tt.wantFlag {
+						t.Errorf("BuildTarCommand() mtime flag = %s, want %s", arg, tt.wantFlag)
+					}
+					break
+				}
+			}
+
+			if tt.wantMtimeFlag && !hasMtimeFlag {
+				t.Errorf("BuildTarCommand() missing --mtime flag, want %s", tt.wantFlag)
+			}
+			if !tt.wantMtimeFlag && hasMtimeFlag {
+				t.Error("BuildTarCommand() has --mtime flag, want none")
+			}
+		})
+	}
+}
+
+func TestBuildTarCommand_MtimePosition(t *testing.T) {
+	// Test that --mtime flag appears before -cf flag
+	cmd := BuildTarCommand(
+		WithOutputFile("test.tar.gz"),
+		WithMtime(1234567890),
+	)
+
+	mtimeIdx := -1
+	cfIdx := -1
+
+	for i, arg := range cmd {
+		if strings.HasPrefix(arg, "--mtime=") {
+			mtimeIdx = i
+		}
+		if arg == "-cf" {
+			cfIdx = i
+		}
+	}
+
+	if mtimeIdx == -1 {
+		t.Error("BuildTarCommand() missing --mtime flag")
+	}
+	if cfIdx == -1 {
+		t.Error("BuildTarCommand() missing -cf flag")
+	}
+	if mtimeIdx >= cfIdx {
+		t.Errorf("BuildTarCommand() --mtime flag at index %d should appear before -cf at index %d", mtimeIdx, cfIdx)
+	}
+}
+
+func TestBuildTarCommand_MtimeWithOtherOptions(t *testing.T) {
+	// Test that mtime works correctly with other options
+	cmd := BuildTarCommand(
+		WithOutputFile("test.tar.gz"),
+		WithSourcePaths("file1.txt", "file2.txt"),
+		WithWorkingDir("/tmp"),
+		WithCompression(true),
+		WithMtime(1234567890),
+	)
+
+	// Verify command contains expected elements
+	cmdStr := strings.Join(cmd, " ")
+
+	expectedElements := []string{
+		"tar",
+		"--mtime=@1234567890",
+		"-cf",
+		"test.tar.gz",
+		"-C",
+		"/tmp",
+		"file1.txt",
+		"file2.txt",
+	}
+
+	for _, elem := range expectedElements {
+		if !strings.Contains(cmdStr, elem) {
+			t.Errorf("BuildTarCommand() missing expected element: %s\nFull command: %s", elem, cmdStr)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

Adds deterministic modification times to tar archives by using the `--mtime` flag with git commit timestamps. This builds on #281 (SBOM normalization) by using the same timestamp source for both SBOMs and tar archives.

## Changes

### Implementation

**`pkg/leeway/compression.go`**
- Added `Mtime int64` field to `TarOptions` struct
- Added `WithMtime(timestamp int64)` option function
- Updated `BuildTarCommand()` to add `--mtime=@{timestamp}` flag when Mtime is set

**`pkg/leeway/build.go`**
- Added `getDeterministicMtime()` helper method that reuses `getGitCommitTimestamp()` from SBOM normalization
- Added `isTestEnvironment()` to detect test context safely
- Updated all 10 `BuildTarCommand()` call sites in:
  - `buildGeneric()` (3 calls)
  - `buildYarn()` (3 calls)  
  - `buildGo()` (1 call)
  - `buildDocker()` (3 calls)

**`pkg/leeway/compression_test.go`** (new)
- Comprehensive unit tests for tar mtime functionality
- Tests option function, flag generation, positioning, and integration
- Test for `isTestEnvironment()` detection

## Why These Changes

### Problem
Tar archives contained non-deterministic file modification times:
- Files used current system time when archived
- Different builds produced different file mtimes
- Made tar archives non-reproducible even with identical content

### Solution
Use `tar --mtime=@{timestamp}` to set all file timestamps to the git commit time, ensuring:
- Same timestamp source as SBOM normalization (consistency)
- Deterministic file mtimes across builds
- Support for `SOURCE_DATE_EPOCH` environment variable

## Three-Tier Timestamp Resolution

The implementation uses a three-tier approach to determine the mtime, prioritizing explicit overrides and failing fast to prevent cache pollution:

### 1. SOURCE_DATE_EPOCH (Highest Priority)
```bash
SOURCE_DATE_EPOCH=1234567890 leeway build :package
```
- Explicit override for reproducible builds
- Standard environment variable for build reproducibility
- Takes precedence over git commit timestamp

### 2. Git Commit Timestamp (Production Default)
```bash
git clone repo && leeway build :package
```
- Uses timestamp from git commit metadata
- Ensures same source → same timestamp
- Maintains cache consistency

### 3. Test Environment Fallback (Test Only)
```bash
go test ./...  # Detected as test environment
```
- Only active when running as test binary (`.test` suffix)
- Or when `LEEWAY_TEST_MODE=true` is explicitly set
- Uses Unix epoch (0) for deterministic test fixtures
- **Never** used in production builds

### Fail-Fast for Cache Protection

If none of the above are available (e.g., building from source tarball without git):
```
ERROR: no git commit available for deterministic mtime.
Ensure repository is properly cloned with git history, or set SOURCE_DATE_EPOCH.
Building from source tarballs without git metadata will cause cache inconsistencies.
```

This prevents **cache pollution** where the same source code produces different checksums depending on how it was obtained (git clone vs source tarball).

## Consistency with SBOM Normalization

Both features use the same `getGitCommitTimestamp()` function:

```
Git commit: 2025-11-17 16:22:01 UTC
  ↓
getGitCommitTimestamp() → 1731862921
  ↓
SBOM: "timestamp": "2025-11-17T16:22:01Z"  ✅
  ↓
Tar: --mtime=@1731862921  ✅
  ↓
Everything uses the same timestamp!
```

## Testing

### Unit Tests
```bash
go test -v ./pkg/leeway -run "TestWithMtime|TestBuildTarCommand.*Mtime|TestIsTestEnvironment"
```

All test functions pass with coverage for:
- Option function behavior
- Flag generation
- Flag positioning in command
- Integration with other options
- Test environment detection

### Manual Verification
```bash
# Build twice
rm -rf /tmp/leeway-cache
leeway build //:helloworld -Dversion=test1 --save /tmp/build1.tar.gz

rm -rf /tmp/leeway-cache  
leeway build //:helloworld -Dversion=test1 --save /tmp/build2.tar.gz

# Verify file timestamps are identical
tar -tvzf /tmp/build1.tar.gz | head -5
tar -tvzf /tmp/build2.tar.gz | head -5
# Both show: 2025-11-18 15:54 (git commit time)

# Verify --mtime flag is used
leeway build //:helloworld -v 2>&1 | grep mtime
# Shows: tar --sparse --mtime=@1763481262 -cf ...
```

### Reproducible Builds with SOURCE_DATE_EPOCH
```bash
# Build with explicit timestamp
SOURCE_DATE_EPOCH=1234567890 leeway build :package --save /tmp/build.tar.gz

# Verify timestamp
tar -tvzf /tmp/build.tar.gz | head -5
# Shows: 2009-02-13 23:31 (SOURCE_DATE_EPOCH timestamp)
```

## Example Output

**Generated tar command:**
```bash
tar --sparse --mtime=@1763481262 -cf output.tar.gz --use-compress-program=gzip -n .
```

**File timestamps in archive:**
```
drwxr-xr-x vscode/vscode     0 2025-11-18 15:54 ./
-rw-r--r-- vscode/vscode  1067 2025-11-18 15:54 ./sbom.spdx.json
-rw-r--r-- vscode/vscode  4118 2025-11-18 15:54 ./sbom.json
-rw-r--r-- vscode/vscode   585 2025-11-18 15:54 ./sbom.cdx.json
```

All files have the same timestamp (git commit time), making the tar archive metadata deterministic.

## Error Handling

### Production Build Without Git
```
ERROR: no git commit available for deterministic mtime.
Ensure repository is properly cloned with git history, or set SOURCE_DATE_EPOCH environment variable.
Building from source tarballs without git metadata will cause cache inconsistencies.
```

### Invalid SOURCE_DATE_EPOCH
```
ERROR: invalid SOURCE_DATE_EPOCH: strconv.ParseInt: parsing "invalid": invalid syntax
```

### Git Command Failure
```
ERROR: failed to get deterministic timestamp for tar mtime (commit: abc123): failed to get commit timestamp: exit status 128.
Ensure git is available and the repository is not a shallow clone, or set SOURCE_DATE_EPOCH environment variable.
```

## Cache Consistency

### Before (Non-Deterministic)
```bash
# Build 1: Files get current time
$ leeway build :package
→ file mtimes = 2025-11-18 10:00:00
→ artifact checksum = aaa111

# Build 2: Files get different current time
$ leeway build :package
→ file mtimes = 2025-11-18 10:05:00  ❌ Different!
→ artifact checksum = bbb222  ❌ Different!
→ cache miss!
```

### After (Deterministic)
```bash
# Build 1: Files get git commit time
$ leeway build :package
→ file mtimes = 2025-11-17 16:22:01  (git commit)
→ artifact checksum = aaa111

# Build 2: Files get same git commit time
$ leeway build :package
→ file mtimes = 2025-11-17 16:22:01  ✅ Same!
→ artifact checksum = aaa111  ✅ Same!
→ cache hit!  ✅
```

### Cache Pollution Prevention

**Without fail-fast (dangerous):**
```bash
# Git clone: uses commit timestamp
$ git clone repo && leeway build :package
→ mtime = 1700000000
→ checksum = aaa111

# Source tarball: silently uses epoch 0
$ wget source.tar.gz && leeway build :package
→ mtime = 0  ❌ Different!
→ checksum = bbb222  ❌ Cache pollution!
```

**With fail-fast (safe):**
```bash
# Git clone: uses commit timestamp
$ git clone repo && leeway build :package
→ mtime = 1700000000
→ checksum = aaa111

# Source tarball: fails with clear error
$ wget source.tar.gz && leeway build :package
→ ERROR: no git commit available
→ No cache pollution!  ✅
```

## Breaking Changes

None. This is a non-breaking enhancement that makes builds more deterministic.

## Dependencies

- Depends on #281 (SBOM normalization) for the `getGitCommitTimestamp()` function
- #281 has been merged into main

## Related

- Part of the deterministic builds initiative
- Complements SBOM normalization (#281)
- Enables more reliable caching and attestation verification
- Fixes https://linear.app/ona-team/issue/CLC-2097/improve-builds-determinism

Co-authored-by: Ona <no-reply@ona.com>