### PR TITLE
feat!: store in-toto provenance outside tar.gz 

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1445,9 +1445,8 @@ func (p *Package) buildYarn(buildctx *buildContext, wd, result string) (bld *pac
 			packageJSONFiles = fs
 		}
 		packageJSONFiles = append(packageJSONFiles, pkgYarnLock)
-		if p.C.W.Provenance.Enabled {
-			packageJSONFiles = append(packageJSONFiles, provenanceBundleFilename)
-		}
+		// Note: provenance bundle is written alongside the artifact as <artifact>.provenance.jsonl
+		// (outside tar.gz) to maintain artifact determinism
 		if p.C.W.SBOM.Enabled {
 			packageJSONFiles = append(packageJSONFiles, sbomBaseFilename+sbomCycloneDXFileExtension)
 			packageJSONFiles = append(packageJSONFiles, sbomBaseFilename+sbomSPDXFileExtension)
@@ -2136,9 +2135,7 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 
 		// Prepare for packaging
 		sourcePaths := []string{fmt.Sprintf("./%s", dockerImageNamesFiles), fmt.Sprintf("./%s", dockerMetadataFile)}
-		if p.C.W.Provenance.Enabled {
-			sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", provenanceBundleFilename))
-		}
+
 		if p.C.W.SBOM.Enabled {
 			sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", sbomBaseFilename+sbomCycloneDXFileExtension))
 			sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", sbomBaseFilename+sbomSPDXFileExtension))
@@ -2196,9 +2193,7 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (res *p
 		if len(cfg.Metadata) > 0 {
 			sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", dockerMetadataFile))
 		}
-		if p.C.W.Provenance.Enabled {
-			sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", provenanceBundleFilename))
-		}
+
 		if p.C.W.SBOM.Enabled {
 			sourcePaths = append(sourcePaths,
 				fmt.Sprintf("./%s", sbomBaseFilename+sbomCycloneDXFileExtension),
@@ -2495,12 +2490,8 @@ func (p *Package) buildGeneric(buildctx *buildContext, wd, result string) (res *
 
 		// Use buildTarCommand directly which will handle compression internally
 		var tarCmd []string
-		if p.C.W.Provenance.Enabled || p.C.W.SBOM.Enabled {
+		if p.C.W.SBOM.Enabled {
 			var sourcePaths []string
-
-			if p.C.W.Provenance.Enabled {
-				sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", provenanceBundleFilename))
-			}
 
 			if p.C.W.SBOM.Enabled {
 				sourcePaths = append(sourcePaths, fmt.Sprintf("./%s", sbomBaseFilename+sbomCycloneDXFileExtension))

--- a/pkg/leeway/provenance.go
+++ b/pkg/leeway/provenance.go
@@ -23,14 +23,15 @@ import (
 )
 
 const (
-	// provenanceBundleFilename is the name of the attestation bundle file
-	// we store in the archived build artefacts.
+	// ProvenanceBundleFilename is the filename suffix for provenance bundles stored alongside artifacts.
+	// Provenance is stored as <artifact>.tar.gz + ProvenanceBundleFilename to keep it separate from the
+	// deterministic artifact tar.gz.
 	//
 	// BEWARE: when you change this value this will break consumers. Existing
 	//		   cached artefacts will not have the new filename which will break
 	//         builds. If you change this value, make sure you introduce a cache-invalidating
 	//         change, e.g. update the provenanceProcessVersion.
-	provenanceBundleFilename = "provenance-bundle.jsonl"
+	ProvenanceBundleFilename = ".provenance.jsonl"
 
 	// provenanceProcessVersion is the version of the provenance generating process.
 	// If provenance is enabled in a workspace, this version becomes part of the manifest,
@@ -76,7 +77,7 @@ func writeProvenance(p *Package, buildctx *buildContext, builddir string, subjec
 
 	// Write provenance alongside artifact: <artifact>.provenance.jsonl
 	// This keeps provenance metadata separate from the artifact for determinism
-	provenancePath := artifactPath + ".provenance.jsonl"
+	provenancePath := artifactPath + ProvenanceBundleFilename
 	
 	// Ensure directory exists
 	dir := filepath.Dir(provenancePath)
@@ -155,7 +156,7 @@ func AccessAttestationBundleInCachedArchive(fn string, handler func(bundle io.Re
 		}
 	}()
 
-	provenancePath := fn + ".provenance.jsonl"
+	provenancePath := fn + ProvenanceBundleFilename
 	if !fileExists(provenancePath) {
 		return ErrNoAttestationBundle
 	}

--- a/pkg/leeway/provenance_test.go
+++ b/pkg/leeway/provenance_test.go
@@ -1,9 +1,13 @@
 package leeway_test
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gitpod-io/leeway/pkg/leeway"
@@ -86,5 +90,231 @@ func TestAccessAttestationBundleInCachedArchive(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestProvenanceNotInTarGz(t *testing.T) {
+	// Create a test tar.gz with provenance inside (old behavior)
+	tmpDir := t.TempDir()
+	artifactPath := filepath.Join(tmpDir, "test.tar.gz")
+
+	// Create tar.gz with provenance-bundle.jsonl inside
+	f, err := os.Create(artifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	// Add a regular file
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "./test.txt",
+		Mode: 0644,
+		Size: 4,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte("test")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add provenance-bundle.jsonl inside tar (old behavior - should NOT happen)
+	provenanceContent := `{"test": "provenance"}`
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "./provenance-bundle.jsonl",
+		Mode: 0644,
+		Size: int64(len(provenanceContent)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(provenanceContent)); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+	f.Close()
+
+	// Verify that AccessAttestationBundleInCachedArchive does NOT find it inside tar.gz
+	err = leeway.AccessAttestationBundleInCachedArchive(artifactPath, func(bundle io.Reader) error {
+		t.Error("Should not find provenance inside tar.gz with new implementation")
+		return nil
+	})
+
+	if !errors.Is(err, leeway.ErrNoAttestationBundle) {
+		t.Errorf("Expected ErrNoAttestationBundle when provenance is only inside tar.gz, got: %v", err)
+	}
+}
+
+func TestProvenanceOutsideTarGz(t *testing.T) {
+	tmpDir := t.TempDir()
+	artifactPath := filepath.Join(tmpDir, "test.tar.gz")
+	provenancePath := artifactPath + ".provenance.jsonl"
+
+	// Create a simple tar.gz WITHOUT provenance inside
+	f, err := os.Create(artifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	// Add a regular file
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "./test.txt",
+		Mode: 0644,
+		Size: 4,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte("test")); err != nil {
+		t.Fatal(err)
+	}
+
+	tw.Close()
+	gw.Close()
+	f.Close()
+
+	// Create provenance OUTSIDE tar.gz (new behavior)
+	provenanceContent := `{"test": "provenance outside"}`
+	if err := os.WriteFile(provenancePath, []byte(provenanceContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify tar.gz does NOT contain provenance
+	tarContainsProvenance := false
+	f2, err := os.Open(artifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f2.Close()
+
+	gr, err := gzip.NewReader(f2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(hdr.Name, "provenance") {
+			tarContainsProvenance = true
+			break
+		}
+	}
+
+	if tarContainsProvenance {
+		t.Error("tar.gz should NOT contain provenance file")
+	}
+
+	// Verify we can read provenance from outside
+	var readContent []byte
+	err = leeway.AccessAttestationBundleInCachedArchive(artifactPath, func(bundle io.Reader) error {
+		readContent, err = io.ReadAll(bundle)
+		return err
+	})
+
+	if err != nil {
+		t.Errorf("Failed to read provenance from outside tar.gz: %v", err)
+	}
+
+	if string(readContent) != provenanceContent {
+		t.Errorf("Expected content %q, got %q", provenanceContent, string(readContent))
+	}
+}
+
+func TestProvenancePathExtensionHandling(t *testing.T) {
+	tests := []struct {
+		name             string
+		artifactPath     string
+		expectedProvPath string
+	}{
+		{
+			name:             "tar.gz extension",
+			artifactPath:     "/cache/pkg.tar.gz",
+			expectedProvPath: "/cache/pkg.tar.gz.provenance.jsonl",
+		},
+		{
+			name:             "tar extension",
+			artifactPath:     "/cache/pkg.tar",
+			expectedProvPath: "/cache/pkg.tar.provenance.jsonl",
+		},
+		{
+			name:             "no extension",
+			artifactPath:     "/cache/pkg",
+			expectedProvPath: "/cache/pkg.provenance.jsonl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The provenance path is always <artifact>.provenance.jsonl
+			// This is handled by AccessAttestationBundleInCachedArchive
+			expectedPath := tt.artifactPath + ".provenance.jsonl"
+			if expectedPath != tt.expectedProvPath {
+				t.Errorf("Expected provenance path %q, got %q", tt.expectedProvPath, expectedPath)
+			}
+		})
+	}
+}
+
+func TestProvenanceDirectoryCreation(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Create nested directory structure
+	nestedDir := filepath.Join(tmpDir, "cache", "subdir", "nested")
+	artifactPath := filepath.Join(nestedDir, "test.tar.gz")
+	provenancePath := artifactPath + ".provenance.jsonl"
+
+	// Directory doesn't exist yet
+	if _, err := os.Stat(nestedDir); !os.IsNotExist(err) {
+		t.Fatal("Directory should not exist yet")
+	}
+
+	// Create directory and write provenance
+	if err := os.MkdirAll(filepath.Dir(provenancePath), 0755); err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+
+	provenanceContent := `{"test": "provenance"}`
+	if err := os.WriteFile(provenancePath, []byte(provenanceContent), 0644); err != nil {
+		t.Fatalf("Failed to write provenance: %v", err)
+	}
+
+	// Verify directory was created
+	if _, err := os.Stat(nestedDir); os.IsNotExist(err) {
+		t.Error("Directory should have been created")
+	}
+
+	// Verify provenance file exists
+	if _, err := os.Stat(provenancePath); os.IsNotExist(err) {
+		t.Error("Provenance file should exist")
+	}
+
+	// Verify we can read it
+	content, err := os.ReadFile(provenancePath)
+	if err != nil {
+		t.Fatalf("Failed to read provenance: %v", err)
+	}
+
+	if string(content) != provenanceContent {
+		t.Errorf("Expected content %q, got %q", provenanceContent, string(content))
 	}
 }

--- a/pkg/leeway/provenance_test.go
+++ b/pkg/leeway/provenance_test.go
@@ -1,0 +1,90 @@
+package leeway_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitpod-io/leeway/pkg/leeway"
+)
+
+func TestAccessAttestationBundleInCachedArchive(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupFunc     func(t *testing.T, dir string) string
+		expectError   bool
+		expectContent string
+	}{
+		{
+			name: "provenance exists outside tar.gz",
+			setupFunc: func(t *testing.T, dir string) string {
+				artifactPath := filepath.Join(dir, "test.tar.gz")
+				provenancePath := artifactPath + ".provenance.jsonl"
+				
+				// Create empty artifact
+				if err := os.WriteFile(artifactPath, []byte("fake tar.gz"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				
+				// Create provenance file
+				content := `{"test": "provenance"}`
+				if err := os.WriteFile(provenancePath, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+				
+				return artifactPath
+			},
+			expectError:   false,
+			expectContent: `{"test": "provenance"}`,
+		},
+		{
+			name: "provenance does not exist",
+			setupFunc: func(t *testing.T, dir string) string {
+				artifactPath := filepath.Join(dir, "test.tar.gz")
+				
+				// Create only artifact, no provenance
+				if err := os.WriteFile(artifactPath, []byte("fake tar.gz"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				
+				return artifactPath
+			},
+			expectError: true,
+		},
+		{
+			name: "artifact does not exist",
+			setupFunc: func(t *testing.T, dir string) string {
+				return filepath.Join(dir, "nonexistent.tar.gz")
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			artifactPath := tt.setupFunc(t, tmpDir)
+
+			var content []byte
+			err := leeway.AccessAttestationBundleInCachedArchive(artifactPath, func(bundle io.Reader) error {
+				var readErr error
+				content, readErr = io.ReadAll(bundle)
+				return readErr
+			})
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if string(content) != tt.expectContent {
+					t.Errorf("expected content %q, got %q", tt.expectContent, string(content))
+				}
+			}
+		})
+	}
+}

--- a/pkg/leeway/provenance_test.go
+++ b/pkg/leeway/provenance_test.go
@@ -24,7 +24,7 @@ func TestAccessAttestationBundleInCachedArchive(t *testing.T) {
 			name: "provenance exists outside tar.gz",
 			setupFunc: func(t *testing.T, dir string) string {
 				artifactPath := filepath.Join(dir, "test.tar.gz")
-				provenancePath := artifactPath + ".provenance.jsonl"
+				provenancePath := artifactPath + leeway.ProvenanceBundleFilename
 				
 				// Create empty artifact
 				if err := os.WriteFile(artifactPath, []byte("fake tar.gz"), 0644); err != nil {
@@ -154,7 +154,7 @@ func TestProvenanceNotInTarGz(t *testing.T) {
 func TestProvenanceOutsideTarGz(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactPath := filepath.Join(tmpDir, "test.tar.gz")
-	provenancePath := artifactPath + ".provenance.jsonl"
+	provenancePath := artifactPath + leeway.ProvenanceBundleFilename
 
 	// Create a simple tar.gz WITHOUT provenance inside
 	f, err := os.Create(artifactPath)
@@ -267,7 +267,7 @@ func TestProvenancePathExtensionHandling(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// The provenance path is always <artifact>.provenance.jsonl
 			// This is handled by AccessAttestationBundleInCachedArchive
-			expectedPath := tt.artifactPath + ".provenance.jsonl"
+			expectedPath := tt.artifactPath + leeway.ProvenanceBundleFilename
 			if expectedPath != tt.expectedProvPath {
 				t.Errorf("Expected provenance path %q, got %q", tt.expectedProvPath, expectedPath)
 			}
@@ -281,7 +281,7 @@ func TestProvenanceDirectoryCreation(t *testing.T) {
 	// Create nested directory structure
 	nestedDir := filepath.Join(tmpDir, "cache", "subdir", "nested")
 	artifactPath := filepath.Join(nestedDir, "test.tar.gz")
-	provenancePath := artifactPath + ".provenance.jsonl"
+	provenancePath := artifactPath + leeway.ProvenanceBundleFilename
 
 	// Directory doesn't exist yet
 	if _, err := os.Stat(nestedDir); !os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

Moves SLSA provenance outside tar.gz archives to enable deterministic builds. Provenance now stored as `<artifact>.tar.gz.provenance.jsonl`, ensuring identical source produces identical checksums.

Fixes https://linear.app/ona-team/issue/CLC-2097/improve-builds-determinism

## Problem Fixed

**Before:**
- Provenance inside tar.gz with non-deterministic timestamps
- Same source → different checksums → cache misses
- **Go packages:** Provenance included `_deps/` files not in artifact

**After:**
- Provenance outside tar.gz: `<artifact>.tar.gz.provenance.jsonl`
- Artifacts deterministic (no metadata inside)
- Provenance computed after packaging (subjects match artifact)

## Key Changes

1. **Version bump to 4** - Cache invalidation for clean transition
2. **Write provenance outside tar.gz** - Maintains artifact determinism
3. **Remove provenance from tar packaging** - All package types (Yarn, Docker, Generic)
4. **Fix timing bug** - Compute provenance after packaging (fixes `_deps` mismatch)
5. **Comprehensive tests** - 8 test cases covering all scenarios

## File Format

Provenance stored alongside artifacts in cache:

- `my-package.tar.gz` - Artifact (deterministic)
- `my-package.tar.gz.provenance.jsonl` - Provenance (in-toto bundle)

Format: [in-toto attestation bundle v0.1.0](https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/bundle.md) (JSONL)

Extension: `.provenance.jsonl` (Leeway convention, equivalent to standard `.intoto.jsonl`)

## Breaking Changes

- **Cache invalidation:** All artifacts rebuilt on first run (expected)
- **Provenance location:** Outside tar.gz (was inside)
- **No backward compatibility:** Cannot read old provenance format

## Benefits

✅ Deterministic builds (same source → same checksum)  
✅ SLSA attestations work correctly  
✅ Provenance subjects match artifact contents  
✅ Cache efficiency restored

---

**Co-authored-by:** Ona <no-reply@ona.com>