### PR TITLE
fix: move test coverage collection before packaging phase

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1058,6 +1058,18 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 		}
 	}
 
+	// Handle test coverage if available (before packaging - needs _deps)
+	if bld.TestCoverage != nil {
+		coverage, funcsWithoutTest, funcsWithTest, err := bld.TestCoverage()
+		if err != nil {
+			return err
+		}
+		pkgRep.TestCoverageAvailable = true
+		pkgRep.TestCoveragePercentage = coverage
+		pkgRep.FunctionsWithoutTest = funcsWithoutTest
+		pkgRep.FunctionsWithTest = funcsWithTest
+	}
+
 	// Package the build results
 	if len(bld.Commands[PackageBuildPhasePackage]) > 0 {
 		if err := executeCommandsForPackage(buildctx, p, builddir, bld.Commands[PackageBuildPhasePackage]); err != nil {
@@ -1078,18 +1090,6 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 		if err := handleProvenance(p, buildctx, builddir, bld, sources, now); err != nil {
 			return err
 		}
-	}
-
-	// Handle test coverage if available
-	if bld.TestCoverage != nil {
-		coverage, funcsWithoutTest, funcsWithTest, err := bld.TestCoverage()
-		if err != nil {
-			return err
-		}
-		pkgRep.TestCoverageAvailable = true
-		pkgRep.TestCoveragePercentage = coverage
-		pkgRep.FunctionsWithoutTest = funcsWithoutTest
-		pkgRep.FunctionsWithTest = funcsWithTest
 	}
 
 	// Register newly built package


### PR DESCRIPTION
## Summary

This PR fixes test coverage collection failing with "cannot load module _deps/api-go--lib" by moving it before the packaging phase.

## Problem

**Error:**
```
[frontend/vscode/agent-browser:amd64] package build failed while building
[frontend/vscode/agent-browser:amd64] Reason: cannot collect test coverage: exit status 2: cover: cannot run go list: exit status 1
[frontend/vscode/agent-browser:amd64] go: cannot load module _deps/api-go--lib listed in go.work file: open _deps/api-go--lib/go.mod: no such file or directory
```

**Root Cause:** Test coverage collection runs AFTER packaging phase deletes `_deps/`, but `go tool cover` needs `_deps/` to run `go list`.

**Affected:** Leeway v0.15.0-rc3+ (SLSA-enabled builds only)

## What Happened

### Commit cdb2518 (November 19, 2025)

**Intent:** Fix provenance subjects to accurately reflect final artifact (without `_deps/`)

**Change:** Moved provenance handling AFTER packaging

**Side Effect:** Test coverage was moved along with provenance, breaking it

**Before commit cdb2518:**
```
1. SBOM generation
2. Test coverage ✅ (has access to _deps/)
3. Package phase (rm -rf _deps)
4. Provenance ❌ (subjects included _deps/ files)
```

**After commit cdb2518:**
```
1. SBOM generation
2. Package phase (rm -rf _deps)
3. Provenance ✅ (subjects correct)
4. Test coverage ❌ (no access to _deps/)
```

## The Fix

**Move test coverage back to BEFORE packaging** (where it was, and where it needs to be).

This satisfies all requirements:
- ✅ Test coverage has access to `_deps/` for `go list`
- ✅ SBOM generation has access to `_deps/` for scanning
- ✅ Packaging removes `_deps/` for deterministic builds
- ✅ Provenance computes subjects from final artifact (no `_deps/`)

## Changes

**File:** `pkg/leeway/build.go`

**What changed:**
- Moved test coverage collection block from line 1083 to line 1061
- Updated comment to explain: "(before packaging - needs _deps)"

**Build order after fix:**
```
1. SBOM generation ← needs _deps/
2. Test coverage collection ← needs _deps/
3. Package phase ← removes _deps/
4. Provenance handling ← accurate subjects (no _deps/)
```

## Testing

- ✅ Code compiles successfully
- ✅ All unit tests pass
- ✅ No functional changes, just reordering

## Related

- Fixes issue introduced in commit cdb2518: "fix: move provenance handling after packaging phase"
- Related to commit b5584c57: "Fix go coverage collection by removing deps in packaging"

## Impact

- **Risk:** Very low - simple code move, no logic changes
- **Scope:** Only affects packages with test coverage enabled
- **Benefit:** Fixes test coverage collection in SLSA-enabled builds