### PR TITLE
fix: OCI extraction and SBOM export mode detection

### DIFF
--- a/pkg/leeway/build_test.go
+++ b/pkg/leeway/build_test.go
@@ -118,6 +118,12 @@ func setupMockForUnitTests() func() {
 }
 
 func TestBuildDockerDeps(t *testing.T) {
+	// Enable mock for this test since it uses dummy docker (not real Docker)
+	// Without the mock, container extraction would fail because dummy docker
+	// doesn't create real images or OCI tars
+	restoreMock := setupMockForUnitTests()
+	defer restoreMock()
+
 	if *testutil.Dut {
 		pth, err := os.MkdirTemp("", "")
 		if err != nil {
@@ -548,6 +554,12 @@ func TestDockerPackage_BuildContextOverride(t *testing.T) {
 }
 
 func TestDockerPostProcessing(t *testing.T) {
+	// Enable mock for this test since it uses dummy docker (not real Docker)
+	// Without the mock, container extraction would fail because dummy docker
+	// doesn't create real images or OCI tars
+	restoreMock := setupMockForUnitTests()
+	defer restoreMock()
+
 	if *testutil.Dut {
 		pth, err := os.MkdirTemp("", "")
 		if err != nil {

--- a/pkg/leeway/container_image.go
+++ b/pkg/leeway/container_image.go
@@ -47,7 +47,13 @@ func extractImageWithOCILibsImpl(destDir, imgTag string) error {
 
 	// Try to load from OCI tar first (when built with --output type=oci)
 	// The OCI tar is in the parent directory of destDir (the build directory)
-	buildDir := filepath.Dir(filepath.Dir(destDir)) // destDir is buildDir/container/content
+	//
+	// Path structure (created in buildDocker, build.go):
+	//   buildDir = wd (e.g., /var/lib/leeway/build/app--docker.xxx)
+	//   containerDir = buildDir/container
+	//   contentDir = buildDir/container/content  <- this is destDir
+	//   image.tar = buildDir/image.tar
+	buildDir := filepath.Dir(filepath.Dir(destDir))
 	ociTarPath := filepath.Join(buildDir, "image.tar")
 
 	var img v1.Image

--- a/pkg/leeway/container_image.go
+++ b/pkg/leeway/container_image.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -44,16 +45,72 @@ func extractImageWithOCILibsImpl(destDir, imgTag string) error {
 	}
 	defer os.RemoveAll(tempExtractDir) // Clean up temp dir after we're done
 
-	// Parse the image reference
-	ref, err := name.ParseReference(imgTag)
-	if err != nil {
-		return fmt.Errorf("parsing image reference: %w", err)
-	}
+	// Try to load from OCI tar first (when built with --output type=oci)
+	// The OCI tar is in the parent directory of destDir (the build directory)
+	buildDir := filepath.Dir(filepath.Dir(destDir)) // destDir is buildDir/container/content
+	ociTarPath := filepath.Join(buildDir, "image.tar")
+	
+	var img v1.Image
+	
+	if _, statErr := os.Stat(ociTarPath); statErr == nil {
+		// OCI tar exists - extract and load from it
+		log.WithField("ociTar", ociTarPath).Debug("Loading image from OCI tar file")
+		
+		// Create a temporary directory to extract the OCI layout
+		ociLayoutDir, err := os.MkdirTemp(buildDir, "oci-layout-")
+		if err != nil {
+			return fmt.Errorf("creating temp dir for OCI layout: %w", err)
+		}
+		defer os.RemoveAll(ociLayoutDir)
+		
+		// Extract the OCI tar to the temporary directory
+		if err := extractTar(ociTarPath, ociLayoutDir); err != nil {
+			return fmt.Errorf("extracting OCI tar: %w", err)
+		}
+		
+		// Load the image from the OCI layout directory
+		layoutPath, err := layout.FromPath(ociLayoutDir)
+		if err != nil {
+			return fmt.Errorf("loading OCI layout from %s: %w", ociLayoutDir, err)
+		}
+		
+		// Get the image index
+		imageIndex, err := layoutPath.ImageIndex()
+		if err != nil {
+			return fmt.Errorf("getting image index from OCI layout: %w", err)
+		}
+		
+		// Get the manifest
+		indexManifest, err := imageIndex.IndexManifest()
+		if err != nil {
+			return fmt.Errorf("getting index manifest: %w", err)
+		}
+		
+		if len(indexManifest.Manifests) == 0 {
+			return fmt.Errorf("no manifests found in OCI layout")
+		}
+		
+		// Get the first image (there should only be one for single-platform builds)
+		img, err = layoutPath.Image(indexManifest.Manifests[0].Digest)
+		if err != nil {
+			return fmt.Errorf("getting image from OCI layout: %w", err)
+		}
+		
+		log.Debug("Successfully loaded image from OCI tar")
+	} else {
+		// OCI tar doesn't exist - fall back to Docker daemon
+		log.Debug("OCI tar not found, loading image from Docker daemon")
+		
+		ref, err := name.ParseReference(imgTag)
+		if err != nil {
+			return fmt.Errorf("parsing image reference: %w", err)
+		}
 
-	// Get the image from the local Docker daemon
-	img, err := daemon.Image(ref)
-	if err != nil {
-		return fmt.Errorf("getting image from daemon: %w", err)
+		img, err = daemon.Image(ref)
+		if err != nil {
+			return fmt.Errorf("getting image from daemon: %w", err)
+		}
+		log.Debug("Successfully loaded image from Docker daemon")
 	}
 
 	// Get image config to check if it's a scratch image
@@ -411,4 +468,58 @@ func copyFileOrDirectory(src, dst string) error {
 
 	_, err = io.Copy(destination, source)
 	return err
+}
+
+// extractTar extracts a tar archive to a destination directory
+func extractTar(tarPath, destDir string) error {
+	file, err := os.Open(tarPath)
+	if err != nil {
+		return fmt.Errorf("opening tar file: %w", err)
+	}
+	defer file.Close()
+
+	tarReader := tar.NewReader(file)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		target := filepath.Join(destDir, header.Name)
+
+		// Ensure the target is within destDir (security check)
+		if !strings.HasPrefix(filepath.Clean(target), filepath.Clean(destDir)) {
+			return fmt.Errorf("illegal file path in tar: %s", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+		case tar.TypeReg:
+			// Create parent directories
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return fmt.Errorf("creating parent directory: %w", err)
+			}
+
+			// Create file
+			outFile, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("creating file: %w", err)
+			}
+
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				outFile.Close()
+				return fmt.Errorf("writing file: %w", err)
+			}
+			outFile.Close()
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

Fixes two bugs related to OCI layout handling when `exportToCache=true`:

1. **Container extraction**: Failed with "No such image" when Docker package has no `image:` config
2. **SBOM generation**: Used different precedence logic than build, causing mismatched export mode decisions

Part of https://linear.app/ona-team/issue/CLC-2009/docker-export-mode-for-slsa-l3-compliance-leeway

## Bug 1: Container Extraction

**Problem**: Build creates `image.tar` with OCI layout but extraction tries Docker daemon, which fails because image was never loaded.

**Fix**: `extractImageWithOCILibsImpl()` now checks for `image.tar` first and extracts from OCI layout when present.

## Bug 2: SBOM Export Mode

**Problem**: SBOM had simplified 3-layer precedence for `exportToCache`, while build uses 5-layer via `determineDockerExportMode()`. This caused SBOM to scan wrong source (OCI vs Docker daemon).

**Example**: Package has `exportToCache=true`, user sets env var to `false`. Build correctly uses Docker daemon, but SBOM tried to scan `image.tar` → failed.

**Fix**: SBOM now calls `determineDockerExportMode()` for consistent behavior.

## Changes

- `container_image.go`: Extract from OCI tar when present, reuse `extractTarToDir`
- `sbom.go`: Call `determineDockerExportMode()` instead of duplicating logic
- `build_test.go`: Make mock opt-in for unit tests
- `build_integration_test.go`: Add tests for both bugs

## Testing

All integration tests pass:
- `TestDockerPackage_OCIExtraction_NoImage_Integration`
- `TestDockerPackage_SBOM_OCI_Integration`
- `TestDockerPackage_SBOM_UserEnvOverridesPackageConfig_Integration`

Co-authored-by: Ona <no-reply@ona.com>