### PR TITLE
fix: skip vulnerability scanning for packages that failed to build

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -748,8 +748,10 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 
 	// Scan all packages for vulnerabilities after the build completes
 	// This ensures we scan even cached packages that weren't rebuilt
+	// Only scan packages that were successfully built or downloaded to avoid
+	// errors when a dependency build failed in a parallel goroutine
 	if pkg.C.W.SBOM.Enabled && pkg.C.W.SBOM.ScanVulnerabilities {
-		if err := scanAllPackagesForVulnerabilities(ctx, allpkg); err != nil {
+		if err := scanAllPackagesForVulnerabilities(ctx, allpkg, pkgstatus); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes vulnerability scanning crash when a dependency build fails in a parallel goroutine but the main build continues due to the build lock mechanism.

Fixes https://linear.app/ona-team/issue/CLC-2122/scan-vulnerabilities-of-packages-iff-their-build-status-is-successful

## Problem

In gitpod-next PR #11869, the build fails with:
```
[api/go:lib] Package api/go:lib not found in local cache, cannot scan for vulnerabilities
build failed
```

## Root Cause: Build Lock Race Condition

Leeway builds dependencies in parallel using goroutines. When multiple packages depend on the same package, a build lock prevents duplicate builds. However, this creates a race condition when a build fails:

### The Scenario
```
Package A ──┐
            ├──> api/go:lib (shared dependency)
Package B ──┘
```

### What Happens

1. **Goroutine A** obtains lock for `api/go:lib`, starts building, build fails, releases lock, returns error
2. **Goroutine B** waits on lock, wakes up when released, **returns `nil` (success) without building**
3. **Main Build** continues if dependency chain goes through Goroutine B
4. **Vulnerability scanning** runs and crashes because `api/go:lib` isn't in cache

### Code Evidence

In `pkg/leeway/build.go`:
```go
func (p *Package) build(buildctx *buildContext) (err error) {
    doBuild := buildctx.ObtainBuildLock(p)
    if !doBuild {
        // Another goroutine is already building this package
        return nil  // ← Returns success even if other goroutine failed!
    }
    // ... actual build ...
}
```

## The Fix

Vulnerability scanning now:
- Receives the `pkgstatus` map tracking build outcomes
- Only scans packages with status `PackageBuilt` or `PackageDownloaded`
- Skips packages that failed or weren't built
- Logs which packages are skipped and why

This prevents the fatal error in vulnerability scanning while still allowing the build to fail if the dependency error propagates through the main dependency chain.

## Changes

- `pkg/leeway/build.go`: Pass `pkgstatus` to vulnerability scanning
- `pkg/leeway/sbom-scan.go`: Filter packages by build status before scanning

## Testing

- ✅ Unit tests pass
- ✅ Integration tests pass
- ✅ Handles the specific scenario from gitpod-next PR #11869

## Related

- Builds on top of PR #296 (SBOM environment variable fix)
- Fixes issue discovered in gitpod-next PR #11869