### PR TITLE
fix(yarn): add `--frozen-lockfile` to default install command

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1357,7 +1357,7 @@ cp $DIR/installer-package.json package.json
 $DIR/get_yarn_lock.sh > yarn.lock
 
 mkdir -p _temp_yarn_cache
-yarn install --frozenlockfile --prod --cache-folder _temp_yarn_cache
+yarn install --frozen-lockfile --prod --cache-folder _temp_yarn_cache
 rm -r yarn.lock _temp_yarn_cache
 `
 


### PR DESCRIPTION
## Problem

The default yarn install command doesn't use `--frozen-lockfile`:

```go
[]string{"yarn", "install", "--mutex", yarnMutex, "--cache-folder", yarnCache}
```

This means `yarn install` can update `yarn.lock` if `package.json` specifies version ranges and newer versions are available.

Fixes https://linear.app/ona-team/issue/PDE-175/leeway-review-and-fix-mis-use-of-yarn

## Fix

Add `--frozen-lockfile` to the default install command.

## Impact

### Reproducibility
- Builds are deterministic: same `yarn.lock` → same dependencies
- Build fails if `package.json` and `yarn.lock` are out of sync (instead of silently updating)

### Security
- **Prevents dependency confusion attacks**: Without `--frozen-lockfile`, if `package.json` specifies `^1.0.0` and a malicious `1.0.1` is published, `yarn install` could fetch it. With `--frozen-lockfile`, the build fails instead.
- **Ensures lockfile integrity**: The lockfile contains checksums. Any mismatch causes failure rather than silent update.

## Note

Packages can override the install command via `commands.install` in BUILD.yaml if they need different behavior.