### PR TITLE
fix!: correct typo in vet check name

### DIFF
--- a/pkg/vet/docker.go
+++ b/pkg/vet/docker.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	register(PackageCheck("copy-from-pacakge", "attempts to find broken package paths in COPY and ADD statements", leeway.DockerPackage, checkDockerCopyFromPackage))
+	register(PackageCheck("copy-from-package", "attempts to find broken package paths in COPY and ADD statements", leeway.DockerPackage, checkDockerCopyFromPackage))
 }
 
 var (


### PR DESCRIPTION
Renames `docker:copy-from-pacakge` to `docker:copy-from-package`.

**BREAKING CHANGE:** Users referencing this check by name (e.g., `leeway vet --checks docker:copy-from-pacakge`) must update to the corrected spelling.