### PR TITLE
fix(cache): require dependencies in local cache for cached packages

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1435,13 +1435,14 @@ func validateDependenciesAvailable(p *Package, localCache cache.LocalCache, pkgs
 		_, inCache := localCache.Location(dep)
 		status := pkgstatus[dep]
 
-		// Dependency is available if:
-		// 1. It's in the local cache (PackageBuilt or PackageDownloaded), OR
-		// 2. It will be built locally (PackageNotBuiltYet), OR
-		// 3. It will be downloaded (PackageInRemoteCache)
+		// Dependency is available if it's actually in the local cache.
+		//
+		// We explicitly do NOT consider PackageNotBuiltYet or PackageInRemoteCache
+		// as "available" here. This function validates cached packages, and cached
+		// packages skip buildDependencies() in build(). If we considered
+		// PackageNotBuiltYet as available, the dependency would never be built,
+		// causing "package X is not built" errors during the prep phase.
 		depAvailable := inCache ||
-			status == PackageNotBuiltYet ||
-			status == PackageInRemoteCache ||
 			status == PackageBuilt ||
 			status == PackageDownloaded
 


### PR DESCRIPTION
## Problem

Flaky CI failures with error: `package "X" is not built`

This occurs when:
1. A package downloads successfully from remote cache
2. One of its transitive dependencies fails to download
3. The cached package passes validation (incorrectly)
4. During build prep, the missing dependency causes failure

Part of https://linear.app/ona-team/issue/CLC-2085/fix-leeway-slsa-verification-to-enable-remote-cache

## Root Cause

`validateDependenciesAvailable()` considered `PackageNotBuiltYet` and `PackageInRemoteCache` as "available" for cached packages. But cached packages skip `buildDependencies()` in `build()`, so these dependencies would never be built/downloaded.

```go
// Before: considered "available" even if not in cache
depAvailable := inCache ||
    status == PackageNotBuiltYet ||      // BUG: won't be built
    status == PackageInRemoteCache ||    // BUG: won't be downloaded
    status == PackageBuilt ||
    status == PackageDownloaded
```

## Fix

Only consider dependencies available if they are actually in local cache:

```go
// After: must be in cache
depAvailable := inCache ||
    status == PackageBuilt ||
    status == PackageDownloaded
```

## Impact

- **Happy path**: Unchanged (all downloads succeed → fast build)
- **Failure path**: Cached packages with missing dependencies are invalidated and rebuilt locally instead of failing

## Performance Note

This fix may cause more local rebuilds when downloads fail. A follow-up PR will add retry logic to minimize this impact.

## Testing

- Updated unit tests in `build_validate_deps_test.go`
- Verified integration test `TestDependencyValidation_AfterDownload_Integration` passes
- All existing tests pass