### PR TITLE
perf(cache): add environment variables for S3 cache tuning

### DIFF
--- a/pkg/leeway/cache/remote/s3_config_test.go
+++ b/pkg/leeway/cache/remote/s3_config_test.go
@@ -1,0 +1,142 @@
+package remote
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEnvInt(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVar     string
+		envValue   string
+		defaultVal int
+		expected   int
+	}{
+		{
+			name:       "returns default when env var not set",
+			envVar:     "TEST_UNSET_VAR",
+			envValue:   "",
+			defaultVal: 30,
+			expected:   30,
+		},
+		{
+			name:       "returns parsed value when env var is valid integer",
+			envVar:     "TEST_VALID_INT",
+			envValue:   "50",
+			defaultVal: 30,
+			expected:   50,
+		},
+		{
+			name:       "returns default when env var is invalid integer",
+			envVar:     "TEST_INVALID_INT",
+			envValue:   "not-a-number",
+			defaultVal: 30,
+			expected:   30,
+		},
+		{
+			name:       "returns default when env var is zero",
+			envVar:     "TEST_ZERO_INT",
+			envValue:   "0",
+			defaultVal: 30,
+			expected:   30,
+		},
+		{
+			name:       "returns default when env var is negative",
+			envVar:     "TEST_NEGATIVE_INT",
+			envValue:   "-10",
+			defaultVal: 30,
+			expected:   30,
+		},
+		{
+			name:       "returns parsed value for large numbers",
+			envVar:     "TEST_LARGE_INT",
+			envValue:   "1000",
+			defaultVal: 100,
+			expected:   1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up env var before and after test
+			os.Unsetenv(tt.envVar)
+			defer os.Unsetenv(tt.envVar)
+
+			if tt.envValue != "" {
+				os.Setenv(tt.envVar, tt.envValue)
+			}
+
+			result := getEnvInt(tt.envVar, tt.defaultVal)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestS3CacheEnvVarTuning(t *testing.T) {
+	// Save original env vars
+	origWorkerCount := os.Getenv(envvarS3WorkerCount)
+	origDownloadWorkers := os.Getenv(envvarS3DownloadWorkers)
+	origRateLimit := os.Getenv(envvarS3RateLimit)
+	origBurstLimit := os.Getenv(envvarS3BurstLimit)
+
+	// Restore after test
+	defer func() {
+		if origWorkerCount != "" {
+			os.Setenv(envvarS3WorkerCount, origWorkerCount)
+		} else {
+			os.Unsetenv(envvarS3WorkerCount)
+		}
+		if origDownloadWorkers != "" {
+			os.Setenv(envvarS3DownloadWorkers, origDownloadWorkers)
+		} else {
+			os.Unsetenv(envvarS3DownloadWorkers)
+		}
+		if origRateLimit != "" {
+			os.Setenv(envvarS3RateLimit, origRateLimit)
+		} else {
+			os.Unsetenv(envvarS3RateLimit)
+		}
+		if origBurstLimit != "" {
+			os.Setenv(envvarS3BurstLimit, origBurstLimit)
+		} else {
+			os.Unsetenv(envvarS3BurstLimit)
+		}
+	}()
+
+	t.Run("uses defaults when env vars not set", func(t *testing.T) {
+		os.Unsetenv(envvarS3WorkerCount)
+		os.Unsetenv(envvarS3DownloadWorkers)
+		os.Unsetenv(envvarS3RateLimit)
+		os.Unsetenv(envvarS3BurstLimit)
+
+		workerCount := getEnvInt(envvarS3WorkerCount, defaultWorkerCount)
+		downloadWorkers := getEnvInt(envvarS3DownloadWorkers, defaultDownloadWorkerCount)
+		rateLimit := getEnvInt(envvarS3RateLimit, defaultRateLimit)
+		burstLimit := getEnvInt(envvarS3BurstLimit, defaultBurstLimit)
+
+		assert.Equal(t, defaultWorkerCount, workerCount)
+		assert.Equal(t, defaultDownloadWorkerCount, downloadWorkers)
+		assert.Equal(t, defaultRateLimit, rateLimit)
+		assert.Equal(t, defaultBurstLimit, burstLimit)
+	})
+
+	t.Run("uses custom values when env vars set", func(t *testing.T) {
+		os.Setenv(envvarS3WorkerCount, "20")
+		os.Setenv(envvarS3DownloadWorkers, "50")
+		os.Setenv(envvarS3RateLimit, "300")
+		os.Setenv(envvarS3BurstLimit, "500")
+
+		workerCount := getEnvInt(envvarS3WorkerCount, defaultWorkerCount)
+		downloadWorkers := getEnvInt(envvarS3DownloadWorkers, defaultDownloadWorkerCount)
+		rateLimit := getEnvInt(envvarS3RateLimit, defaultRateLimit)
+		burstLimit := getEnvInt(envvarS3BurstLimit, defaultBurstLimit)
+
+		assert.Equal(t, 20, workerCount)
+		assert.Equal(t, 50, downloadWorkers)
+		assert.Equal(t, 300, rateLimit)
+		assert.Equal(t, 500, burstLimit)
+	})
+}


### PR DESCRIPTION
## Motivation

Enable runtime tuning of S3 cache performance without code changes. This allows teams to optimize cache throughput based on their specific workloads and infrastructure.

Part of https://linear.app/ona-team/issue/CLC-2086/optimize-leeway-s3-cache-performance

## New Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `LEEWAY_S3_WORKER_COUNT` | 10 | Number of concurrent workers for uploads and existence checks |
| `LEEWAY_S3_DOWNLOAD_WORKERS` | 30 | Number of concurrent download workers |
| `LEEWAY_S3_RATE_LIMIT` | 100 | S3 API request rate limit (requests/second) |
| `LEEWAY_S3_BURST_LIMIT` | 200 | S3 API burst limit for rate limiting |

## Usage

```bash
# Increase parallelism for faster operations
export LEEWAY_S3_WORKER_COUNT=20
export LEEWAY_S3_DOWNLOAD_WORKERS=50

# Increase rate limits for high-throughput environments
export LEEWAY_S3_RATE_LIMIT=300
export LEEWAY_S3_BURST_LIMIT=500

leeway build
```

## Implementation

- Follows existing Leeway patterns for environment variable configuration
- Uses `getEnvInt()` helper with validation (rejects zero/negative values)
- Logs when non-default values are used for visibility
- Falls back to defaults on invalid input

Note: There's a similar inline pattern in `cmd/sign-cache.go`. A shared utility was considered but would cause import cycles from `cache/remote` → `leeway`. The duplication is minimal (7 lines).

## Testing

- Added unit tests for `getEnvInt()` helper
- Added integration tests for env var tuning
- All existing tests pass

## Stacked On

This PR is stacked on #307 (detailed download results).