### PR TITLE
fix: make `GetTransitiveDependencies` return deterministic order

### DIFF
--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -268,6 +268,9 @@ func (p *Package) GetTransitiveDependencies() []*Package {
 	// Collect keys and sort them for deterministic iteration order.
 	// Map iteration in Go is non-deterministic, which would cause
 	// non-reproducible builds (different go.work content, different checksums).
+	// Note: sort.Strings uses bytewise comparison which is deterministic for
+	// ASCII strings. Package names are ASCII (component:package format), so
+	// this is safe. Unicode normalization is not a concern here.
 	keys := make([]string, 0, len(idx)-1)
 	for k := range idx {
 		if k != p.FullName() {


### PR DESCRIPTION
## Problem

`GetTransitiveDependencies()` iterates over a map to collect results, but map iteration order in Go is non-deterministic. This causes the same package to produce different build artifacts (different checksums) when built on different machines or at different times.

**Impact:**
- `go.work` file content varies (`go work use` commands executed in random order)
- tar archive checksums differ for identical source code
- SLSA attestation verification fails when checksum doesn't match

**Evidence from CI:**
- `_build.yml` built `api/go:lib` with checksum `9f4c1c4c4c34b62b...`
- `build-vscode.yml` built same package with checksum `afe18507539dba38...`
- Same version hash `2c5a536bff2f1be26bcd59ba86f35c14921ef511`, different output

Fixes https://linear.app/ona-team/issue/CLC-2085/fix-leeway-slsa-verification-to-enable-remote-cache

## Solution

Sort dependencies by `FullName()` before returning from `GetTransitiveDependencies()`.

## Changes

1. **Test commit**: Integration tests that prove the non-determinism (fail before fix)
2. **Fix commit**: Sort the keys before iterating

## Testing

```
$ go test -v -tags=integration -run "TestGetTransitiveDependencies" ./pkg/leeway/
=== RUN   TestGetTransitiveDependenciesIsDeterministic
    build_integration_test.go:3035: First order: [test:depA test:depB test:depC test:depD test:depE]
--- PASS: TestGetTransitiveDependenciesIsDeterministic (0.00s)
=== RUN   TestGetTransitiveDependenciesDeepGraphIsDeterministic
    build_integration_test.go:3084: First order: [test:depA test:depB test:depC test:depD]
--- PASS: TestGetTransitiveDependenciesDeepGraphIsDeterministic (0.00s)
=== RUN   TestGetTransitiveDependenciesManyDepsIsDeterministic
    build_integration_test.go:3124: First order (20 deps): [test:depA test:depB ... test:depT]
--- PASS: TestGetTransitiveDependenciesManyDepsIsDeterministic (0.00s)
PASS
```

Stacked on #308