### PR TITLE
fix: add `--sort=name` to tar command for deterministic archives

### DIFF
--- a/pkg/leeway/compression.go
+++ b/pkg/leeway/compression.go
@@ -193,6 +193,10 @@ func BuildTarCommand(options ...func(*TarOptions)) []string {
 	// Add Linux-specific optimizations
 	if runtime.GOOS == "linux" {
 		cmd = append(cmd, "--sparse")
+		// Sort files by name for deterministic archive order.
+		// Without this, file order depends on filesystem directory listing,
+		// which can vary between systems/runs, causing different checksums.
+		cmd = append(cmd, "--sort=name")
 	}
 
 	// Add deterministic mtime if specified


### PR DESCRIPTION
## Problem

The tar command doesn't sort files, so the order in the archive depends on filesystem directory listing order. This can vary between systems/runs, causing different checksums for identical content.

This is the second source of non-determinism (after `GetTransitiveDependencies` fixed in #309) that causes SLSA attestation verification failures when the same package is built on different machines.

Part of https://linear.app/ona-team/issue/CLC-2085/fix-leeway-slsa-verification-to-enable-remote-cache

## Solution

Add `--sort=name` flag to the tar command on Linux. This ensures files are archived in alphabetical order, producing deterministic archives.

## Changes

1. **Test commit**: Unit tests that verify `--sort=name` flag is present (fail before fix)
2. **Fix commit**: Add `--sort=name` to `BuildTarCommand()` on Linux

## Testing

```
$ go test -v -run "TestBuildTarCommand_Sort" ./pkg/leeway/
=== RUN   TestBuildTarCommand_SortFlag
--- PASS: TestBuildTarCommand_SortFlag (0.00s)
=== RUN   TestBuildTarCommand_SortFlagPosition
--- PASS: TestBuildTarCommand_SortFlagPosition (0.00s)
PASS
```

Stacked on #309