### PR TITLE
fix: add -trimpath to default Go build command 

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -2124,7 +2124,8 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 	if len(cfg.BuildCommand) > 0 {
 		buildCmd = cfg.BuildCommand
 	} else if cfg.Packaging == GoApp {
-		buildCmd = []string{goCommand, "build"}
+		// Use -trimpath for reproducible builds: removes absolute file paths from the binary
+		buildCmd = []string{goCommand, "build", "-trimpath"}
 		buildCmd = append(buildCmd, cfg.BuildFlags...)
 		buildCmd = append(buildCmd, ".")
 	}


### PR DESCRIPTION
## Summary

Add `-trimpath` flag to the default Go build command for reproducible builds.

Part of https://linear.app/ona-team/issue/CLC-2085/fix-leeway-slsa-verification-to-enable-remote-cache

Stacked on #311

## Problem

Without `-trimpath`, Go embeds absolute file paths in the binary. These paths vary between build machines (e.g., `/home/user1/project` vs `/home/user2/project`), causing identical source code to produce different binaries.

## Solution

Add `-trimpath` to the default build command when no custom `buildCommand` is specified:

```go
// Before
buildCmd = []string{goCommand, "build"}

// After  
buildCmd = []string{goCommand, "build", "-trimpath"}
```

## Impact

- Packages using the default Go build command will now produce reproducible binaries
- Packages with custom `buildCommand` are unaffected (they should already include `-trimpath` if reproducibility is needed)
- No breaking changes - `-trimpath` only affects debug info paths, not runtime behavior

## Testing

- Added unit test to verify `-trimpath` is included in default build command
- All existing tests pass