### PR TITLE
fix: resolve builtin variables in PackageInternal (prep, env)

### DIFF
--- a/pkg/leeway/package.go
+++ b/pkg/leeway/package.go
@@ -840,6 +840,20 @@ func (p *Package) resolveBuiltinVariables() error {
 		}
 	}
 
+	// Resolve builtin variables in PackageInternal (prep, env, etc.)
+	pifc, err := yaml.Marshal(p.PackageInternal)
+	if err != nil {
+		return err
+	}
+	pifc = replaceBuildArguments(pifc, builtinArgs)
+	var pi PackageInternal
+	err = yaml.Unmarshal(pifc, &pi)
+	if err != nil {
+		return err
+	}
+	p.PackageInternal = pi
+
+	// Resolve builtin variables in Config
 	type configOnlyHelper struct {
 		Config PackageConfig `yaml:"config"`
 	}


### PR DESCRIPTION
## Summary

Resolve builtin variables (`${__pkg_version}`, `${__git_commit}`, `${__git_commit_short}`) in `PackageInternal` fields (prep, env), not just in `Config`.

Part of https://linear.app/ona-team/issue/CLC-2147/fix-non-deterministic-version-across-packages

## Problem

`resolveBuiltinVariables()` only resolved builtin variables in `Config`, but `FindUnresolvedArguments()` checks both `PackageInternal` and `Config`. This caused builtin variables in `prep` or `env` fields to be flagged as unresolved, failing the build with:

```
cannot build with unresolved argument "${__git_commit_short}": use -D__git_commit_short=value to set the argument
```

Example BUILD.yaml that would fail:
```yaml
packages:
  - name: app
    type: yarn
    prep:
      - ["/bin/bash", "prepare.sh", "${__pkg_version}"]  # This was NOT resolved
    config:
      commands:
        build: ["./package.sh", "${__git_commit_short}"]  # This WAS resolved
```

## Solution

Resolve builtin variables in `PackageInternal` before resolving in `Config`.

## Testing

- Added `TestResolveBuiltinVariablesInPackageInternal` test
- All existing tests pass