### PR TITLE
fix: upload (external) SBOM files alongside artifacts

### DIFF
--- a/pkg/leeway/cache/remote/s3.go
+++ b/pkg/leeway/cache/remote/s3.go
@@ -1446,23 +1446,11 @@ func (s *S3Cache) uploadProvenanceBundle(ctx context.Context, packageName, artif
 	}).Debug("Successfully uploaded provenance bundle to remote cache")
 }
 
-// SBOM file extensions - must match pkg/leeway/sbom.go constants
-const (
-	sbomBaseFilename           = "sbom"
-	sbomCycloneDXFileExtension = ".cdx.json"
-	sbomSPDXFileExtension      = ".spdx.json"
-	sbomSyftFileExtension      = ".json"
-)
-
 // uploadSBOMFiles uploads SBOM files to S3 with retry logic.
 // This is a non-blocking operation - failures are logged but don't fail the build.
 // SBOM files are stored alongside artifacts as <artifact>.sbom.<ext>
 func (s *S3Cache) uploadSBOMFiles(ctx context.Context, packageName, artifactKey, localPath string) {
-	sbomExtensions := []string{
-		"." + sbomBaseFilename + sbomCycloneDXFileExtension,
-		"." + sbomBaseFilename + sbomSPDXFileExtension,
-		"." + sbomBaseFilename + sbomSyftFileExtension,
-	}
+	sbomExtensions := cache.SBOMSidecarExtensions()
 
 	for _, ext := range sbomExtensions {
 		sbomPath := localPath + ext
@@ -1510,11 +1498,7 @@ func (s *S3Cache) uploadSBOMFiles(ctx context.Context, packageName, artifactKey,
 // This is a best-effort operation - missing SBOMs are expected for older artifacts.
 // SBOM files are stored alongside artifacts as <artifact>.sbom.<ext>
 func (s *S3Cache) downloadSBOMFiles(ctx context.Context, packageName, artifactKey, localPath string) {
-	sbomExtensions := []string{
-		"." + sbomBaseFilename + sbomCycloneDXFileExtension,
-		"." + sbomBaseFilename + sbomSPDXFileExtension,
-		"." + sbomBaseFilename + sbomSyftFileExtension,
-	}
+	sbomExtensions := cache.SBOMSidecarExtensions()
 
 	for _, ext := range sbomExtensions {
 		sbomPath := localPath + ext

--- a/pkg/leeway/cache/types.go
+++ b/pkg/leeway/cache/types.go
@@ -1,5 +1,12 @@
 // Package cache provides local and remote caching capabilities for build artifacts.
 //
+// SBOM Sidecar Files:
+// SBOM (Software Bill of Materials) files are stored alongside artifacts as sidecar files.
+// The naming convention is: <artifact>.<extension> where extension is one of:
+//   - .sbom.cdx.json  (CycloneDX format)
+//   - .sbom.spdx.json (SPDX format)
+//   - .sbom.json      (Syft native format)
+//
 // SLSA Verification Behavior:
 // The cache system supports SLSA (Supply-chain Levels for Software Artifacts) verification
 // for enhanced security. The behavior is controlled by the SLSAConfig.RequireAttestation field:
@@ -26,6 +33,31 @@ package cache
 import (
 	"context"
 )
+
+// SBOM file format constants
+const (
+	// SBOMBaseFilename is the base filename for SBOM files (e.g., "sbom" in "artifact.sbom.cdx.json")
+	SBOMBaseFilename = "sbom"
+
+	// SBOMCycloneDXFileExtension is the extension of the CycloneDX SBOM file
+	SBOMCycloneDXFileExtension = ".cdx.json"
+
+	// SBOMSPDXFileExtension is the extension of the SPDX SBOM file
+	SBOMSPDXFileExtension = ".spdx.json"
+
+	// SBOMSyftFileExtension is the extension of the Syft SBOM file
+	SBOMSyftFileExtension = ".json"
+)
+
+// SBOMSidecarExtensions returns all SBOM sidecar file extensions.
+// These are the extensions used for SBOM files stored alongside artifacts.
+func SBOMSidecarExtensions() []string {
+	return []string{
+		"." + SBOMBaseFilename + SBOMCycloneDXFileExtension, // .sbom.cdx.json
+		"." + SBOMBaseFilename + SBOMSPDXFileExtension,      // .sbom.spdx.json
+		"." + SBOMBaseFilename + SBOMSyftFileExtension,      // .sbom.json
+	}
+}
 
 // Package represents a build package that can be cached
 type Package interface {

--- a/pkg/leeway/signing/upload.go
+++ b/pkg/leeway/signing/upload.go
@@ -108,12 +108,15 @@ func (u *ArtifactUploader) UploadArtifactWithAttestation(ctx context.Context, ar
 		}
 
 		if attestationExists {
-			// Both artifact and attestation exist, skip both uploads
+			// Both artifact and attestation exist, but still check SBOM files
 			log.WithFields(log.Fields{
 				"artifact":     artifactPath,
 				"artifact_key": artifactKey,
 				"att_key":      attestationKey,
-			}).Info("Skipping attestation upload (artifact and attestation already exist)")
+			}).Info("Skipping artifact and attestation upload (already exist)")
+
+			// Still upload SBOM files if missing
+			u.uploadSBOMFiles(ctx, artifactPath, artifactKey)
 			return nil
 		}
 
@@ -133,6 +136,9 @@ func (u *ArtifactUploader) UploadArtifactWithAttestation(ctx context.Context, ar
 			"artifact_key": artifactKey,
 			"att_key":      attestationKey,
 		}).Info("Successfully uploaded attestation")
+
+		// Also upload SBOM files if missing
+		u.uploadSBOMFiles(ctx, artifactPath, artifactKey)
 		return nil
 	}
 

--- a/pkg/leeway/signing/upload.go
+++ b/pkg/leeway/signing/upload.go
@@ -176,12 +176,7 @@ func (u *ArtifactUploader) UploadArtifactWithAttestation(ctx context.Context, ar
 // uploadSBOMFiles uploads SBOM sidecar files alongside the artifact.
 // This is a non-blocking operation - failures are logged but don't fail the upload.
 func (u *ArtifactUploader) uploadSBOMFiles(ctx context.Context, artifactPath, artifactKey string) {
-	// SBOM file extensions - must match pkg/leeway/sbom.go constants
-	sbomExtensions := []string{
-		".sbom.cdx.json",  // CycloneDX format
-		".sbom.spdx.json", // SPDX format
-		".sbom.json",      // Syft native format
-	}
+	sbomExtensions := cache.SBOMSidecarExtensions()
 
 	for _, ext := range sbomExtensions {
 		sbomPath := artifactPath + ext


### PR DESCRIPTION
## Summary

Upload SBOM sidecar files alongside artifacts when using the `sign-cache` command.

**Stacked on #314**

## Changes

1. **Add SBOM upload to sign-cache** (`signing/upload.go`)
   - Upload `.sbom.cdx.json`, `.sbom.spdx.json`, `.sbom.json` files alongside artifacts
   - Check if SBOM exists locally before upload
   - Check if SBOM already exists in remote cache to avoid re-upload
   - Non-blocking: failures are logged but don't fail the upload

2. **Fix SBOM upload when artifact already exists**
   - When artifact/attestation already exist in cache, still check and upload missing SBOM files
   - Covers all code paths in `UploadArtifactWithAttestation`

3. **Consolidate SBOM constants** (`cache/types.go`)
   - Move SBOM extension constants to single location
   - Add `SBOMSidecarExtensions()` function
   - Remove duplication from `sbom.go`, `s3.go`, `signing/upload.go`

## Testing

- All existing tests pass
- Manual testing with SLSA L3 cache verification in gitpod-next CI