### PR TITLE
Graceful otel shutdown on build failure

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -99,6 +99,7 @@ func build(cmd *cobra.Command, args []string) error {
 					if save != "" {
 						err = saveBuildResult(ctx, save, localCache, pkg)
 						if err != nil {
+							cancel()
 							return err
 						}
 					}
@@ -109,6 +110,7 @@ func build(cmd *cobra.Command, args []string) error {
 					log.Error(err)
 				}
 			case err = <-errs:
+				cancel()
 				return err
 			}
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -80,6 +80,7 @@ func build(cmd *cobra.Command, args []string) error {
 		if save != "" {
 			err = saveBuildResult(ctx, save, localCache, pkg)
 			if err != nil {
+				cancel()
 				return err
 			}
 		}

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -131,7 +131,7 @@ func newBuildContext(options buildOptions) (ctx *buildContext, err error) {
 
 	// Ensure cache directory exists with proper permissions
 	if err := os.MkdirAll(buildDir, 0755); err != nil {
-		log.WithError(err).Fatal("failed to create build directory")
+		return nil, xerrors.Errorf("failed to create build directory: %w", err)
 	}
 
 	var buildLimit *semaphore.Weighted


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When a build fails, leeway was using `log.Fatal` to shutdown, but this doesn't run any defer-ed cleanup functions preventing otel from pushing all spans. Results in incomplete traces

The pr changes the build command to return errors instead of using `log.Fatal`, and then have one top-level `log.Fatal` (after otel shutdown has run).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to CORE-6452

## How to test
<!-- Provide steps to test this PR -->

Complete traces in honeycomb now:
<img width="833" height="154" alt="image" src="https://github.com/user-attachments/assets/584ae345-3551-4551-9702-e7b61d844cf3" />
https://ui.honeycomb.io/gitpod/environments/ci/datasets/leeway/result/e9NjDmof1Yh/trace/pct7KaVe6Z4?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=96f4a3ca1c7caed8

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
