### PR TITLE
Add OpenTelemetry tracing for individual Go tests

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -206,6 +206,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().UintP("max-concurrent-tasks", "j", uint(cpus), "Limit the number of max concurrent build tasks - set to 0 to disable the limit")
 	cmd.Flags().String("coverage-output-path", "", "Output path where test coverage file will be copied after running tests")
 	cmd.Flags().Bool("disable-coverage", false, "Disable test coverage collection (defaults to false)")
+	cmd.Flags().Bool("enable-test-tracing", false, "Enable per-test OpenTelemetry span creation (defaults to false)")
 	cmd.Flags().StringToString("docker-build-options", nil, "Options passed to all 'docker build' commands")
 	cmd.Flags().Bool("slsa-cache-verification", false, "Enable SLSA verification for cached artifacts")
 	cmd.Flags().String("slsa-source-uri", "", "Expected source URI for SLSA verification (required when verification enabled)")
@@ -394,6 +395,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache, C
 	}
 
 	disableCoverage, _ := cmd.Flags().GetBool("disable-coverage")
+	enableTestTracing, _ := cmd.Flags().GetBool("enable-test-tracing")
 
 	var dockerBuildOptions leeway.DockerBuildOptions
 	dockerBuildOptions, err = cmd.Flags().GetStringToString("docker-build-options")
@@ -459,6 +461,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache, C
 		leeway.WithCompressionDisabled(dontCompress),
 		leeway.WithFixedBuildDir(fixedBuildDir),
 		leeway.WithDisableCoverage(disableCoverage),
+		leeway.WithEnableTestTracing(enableTestTracing),
 		leeway.WithInFlightChecksums(inFlightChecksums),
 		leeway.WithDockerExportToCache(dockerExportToCache, dockerExportSet),
 		leeway.WithDockerExportEnv(dockerExportEnvValue, dockerExportEnvSet),

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -25,6 +25,7 @@ import (
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
@@ -1371,13 +1372,7 @@ func executeBuildPhase(buildctx *buildContext, p *Package, builddir string, bld 
 
 	log.WithField("phase", phase).WithField("package", p.FullName()).WithField("commands", bld.Commands[phase]).Debug("running commands")
 
-	var err error
-	// Use TestExecutor for test phase if available (enables per-test tracing)
-	if phase == PackageBuildPhaseTest && bld.TestExecutor != nil {
-		err = bld.TestExecutor(buildctx, p, builddir)
-	} else {
-		err = executeCommandsForPackage(buildctx, p, builddir, cmds)
-	}
+	err := executeCommandsForPackage(buildctx, p, builddir, cmds)
 	pkgRep.phaseDone[phase] = time.Now()
 
 	return err
@@ -1536,11 +1531,6 @@ type packageBuild struct {
 	// It's used for post-build processing that needs to happen regardless of provenance settings,
 	// such as Docker image extraction.
 	PostProcess func(buildCtx *buildContext, pkg *Package, buildDir string) error
-
-	// TestExecutor is an optional function that executes tests with tracing support.
-	// If set, it will be used instead of the standard command execution for the test phase.
-	// This allows Go packages to create spans for individual tests.
-	TestExecutor func(buildctx *buildContext, p *Package, builddir string) error
 }
 
 type testCoverageFunc func() (coverage, funcsWithoutTest, funcsWithTest int, err error)
@@ -2123,7 +2113,6 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 		}
 	}
 	var reportCoverage testCoverageFunc
-	var testExecutor func(buildctx *buildContext, p *Package, builddir string) error
 	if !cfg.DontTest && !buildctx.DontTest {
 		testCommand := []string{goCommand, "test"}
 		if log.IsLevelEnabled(log.DebugLevel) {
@@ -2143,9 +2132,6 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 		testCommand = append(testCommand, "./...")
 
 		commands[PackageBuildPhaseTest] = append(commands[PackageBuildPhaseTest], testCommand)
-
-		// Create test executor for tracing individual tests
-		testExecutor = createGoTestExecutor(testCommand)
 	}
 
 	var buildCmd []string
@@ -2184,51 +2170,7 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 	return &packageBuild{
 		Commands:     commands,
 		TestCoverage: reportCoverage,
-		TestExecutor: testExecutor,
 	}, nil
-}
-
-// createGoTestExecutor creates a test executor function that runs go test with JSON output
-// and creates OpenTelemetry spans for each individual test when a TestTracingReporter is available.
-func createGoTestExecutor(testCommand []string) func(buildctx *buildContext, p *Package, builddir string) error {
-	return func(buildctx *buildContext, p *Package, builddir string) error {
-		// Check if test tracing is enabled
-		if !buildctx.EnableTestTracing {
-			return executeCommandsForPackage(buildctx, p, builddir, [][]string{testCommand})
-		}
-
-		// Check if the reporter supports test tracing
-		tracingReporter, ok := buildctx.Reporter.(TestTracingReporter)
-		if !ok {
-			// Fall back to standard execution without tracing
-			return executeCommandsForPackage(buildctx, p, builddir, [][]string{testCommand})
-		}
-
-		// Get the test tracer from the reporter
-		tracer := tracingReporter.GetGoTestTracer(p)
-		if tracer == nil {
-			// Tracer not available, fall back to standard execution
-			return executeCommandsForPackage(buildctx, p, builddir, [][]string{testCommand})
-		}
-
-		// Set up environment
-		env := append(os.Environ(), p.Environment...)
-		env = append(env, fmt.Sprintf("%s=%s", EnvvarWorkspaceRoot, p.C.W.Origin))
-
-		// Export SOURCE_DATE_EPOCH for reproducible builds
-		mtime, err := p.getDeterministicMtime()
-		if err == nil {
-			env = append(env, fmt.Sprintf("SOURCE_DATE_EPOCH=%d", mtime))
-		}
-		env = append(env, "DOCKER_BUILDKIT=1")
-
-		// Create output writer that reports to the build reporter
-		outputWriter := &reporterStream{R: buildctx.Reporter, P: p, IsErr: false}
-
-		// Run go test with JSON output and create spans for each test
-		log.WithField("package", p.FullName()).WithField("command", strings.Join(testCommand, " ")).Debug("running go test with tracing")
-		return tracer.RunGoTest(context.Background(), env, builddir, testCommand, outputWriter)
-	}
 }
 
 func collectGoTestCoverage(covfile string) testCoverageFunc {
@@ -3124,7 +3066,7 @@ func executeCommandsForPackage(buildctx *buildContext, p *Package, wd string, co
 		if len(cmd) == 0 {
 			continue // Skip empty commands
 		}
-		err := run(buildctx.Reporter, p, env, wd, cmd[0], cmd[1:]...)
+		err := run(buildctx, p, env, wd, cmd[0], cmd[1:]...)
 		if err != nil {
 			return err
 		}
@@ -3132,21 +3074,93 @@ func executeCommandsForPackage(buildctx *buildContext, p *Package, wd string, co
 	return nil
 }
 
-func run(rep Reporter, p *Package, env []string, cwd, name string, args ...string) error {
+// isGoTestCommand checks if the command is a "go test" invocation
+func isGoTestCommand(name string, args []string) bool {
+	if name != "go" {
+		return false
+	}
+	for _, arg := range args {
+		if arg == "test" {
+			return true
+		}
+		// Stop at first non-flag argument that isn't "test"
+		if !strings.HasPrefix(arg, "-") {
+			return false
+		}
+	}
+	return false
+}
+
+func run(buildctx *buildContext, p *Package, env []string, cwd, name string, args ...string) error {
 	log.WithField("package", p.FullName()).WithField("command", strings.Join(append([]string{name}, args...), " ")).Debug("running")
 
-	cmd := exec.Command(name, args...)
-	cmd.Stdout = &reporterStream{R: rep, P: p, IsErr: false}
-	cmd.Stderr = &reporterStream{R: rep, P: p, IsErr: true}
-	cmd.Dir = cwd
-	cmd.Env = env
-	err := cmd.Run()
-
-	if err != nil {
-		return err
+	// Check if this is a go test command and tracing is enabled
+	if buildctx != nil && buildctx.EnableTestTracing && isGoTestCommand(name, args) {
+		if otelRep, ok := findOTelReporter(buildctx.Reporter); ok {
+			if ctx := otelRep.GetPackageContext(p); ctx != nil {
+				return runGoTestWithTracing(buildctx, p, env, cwd, name, args, otelRep.GetTracer(), ctx)
+			}
+		}
 	}
 
-	return nil
+	// Standard command execution
+	cmd := exec.Command(name, args...)
+	if buildctx != nil {
+		cmd.Stdout = &reporterStream{R: buildctx.Reporter, P: p, IsErr: false}
+		cmd.Stderr = &reporterStream{R: buildctx.Reporter, P: p, IsErr: true}
+	}
+	cmd.Dir = cwd
+	cmd.Env = env
+
+	return cmd.Run()
+}
+
+// findOTelReporter finds an OTelReporter in the reporter chain
+func findOTelReporter(rep Reporter) (*OTelReporter, bool) {
+	switch r := rep.(type) {
+	case *OTelReporter:
+		return r, true
+	case CompositeReporter:
+		for _, inner := range r {
+			if otel, ok := findOTelReporter(inner); ok {
+				return otel, ok
+			}
+		}
+	}
+	return nil, false
+}
+
+// runGoTestWithTracing runs go test with JSON output and creates spans for each test
+func runGoTestWithTracing(buildctx *buildContext, p *Package, env []string, cwd, name string, args []string, tracer trace.Tracer, parentCtx context.Context) error {
+	// Build command with -json flag
+	fullArgs := append([]string{name}, args...)
+	jsonArgs := ensureJSONFlag(fullArgs)
+
+	log.WithField("package", p.FullName()).WithField("command", strings.Join(jsonArgs, " ")).Debug("running go test with tracing")
+
+	cmd := exec.Command(jsonArgs[0], jsonArgs[1:]...)
+	cmd.Dir = cwd
+	cmd.Env = env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	cmd.Stderr = &reporterStream{R: buildctx.Reporter, P: p, IsErr: true}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start go test: %w", err)
+	}
+
+	// Create tracer and parse output
+	goTracer := NewGoTestTracer(tracer, parentCtx)
+	outputWriter := &reporterStream{R: buildctx.Reporter, P: p, IsErr: false}
+
+	if err := goTracer.parseJSONOutput(stdout, outputWriter); err != nil {
+		log.WithError(err).Warn("error parsing go test JSON output")
+	}
+
+	return cmd.Wait()
 }
 
 type reporterStream struct {

--- a/pkg/leeway/gotest_trace.go
+++ b/pkg/leeway/gotest_trace.go
@@ -1,0 +1,368 @@
+package leeway
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// goTestEvent represents a single event from `go test -json` output.
+// See https://pkg.go.dev/cmd/test2json for the format specification.
+type goTestEvent struct {
+	Time    time.Time `json:"Time"`
+	Action  string    `json:"Action"`
+	Package string    `json:"Package"`
+	Test    string    `json:"Test"`
+	Output  string    `json:"Output"`
+	Elapsed float64   `json:"Elapsed"` // seconds
+}
+
+// testSpanData holds the span and metadata for an in-progress test
+type testSpanData struct {
+	span      trace.Span
+	startTime time.Time
+	pkg       string
+}
+
+// GoTestTracer handles parsing Go test JSON output and creating OpenTelemetry spans
+type GoTestTracer struct {
+	tracer    trace.Tracer
+	parentCtx context.Context
+
+	mu    sync.Mutex
+	spans map[string]*testSpanData // key: "package/testname" or just "package" for package-level
+}
+
+// NewGoTestTracer creates a new GoTestTracer that will create spans as children of the given context
+func NewGoTestTracer(tracer trace.Tracer, parentCtx context.Context) *GoTestTracer {
+	return &GoTestTracer{
+		tracer:    tracer,
+		parentCtx: parentCtx,
+		spans:     make(map[string]*testSpanData),
+	}
+}
+
+// spanKey generates a unique key for a test span
+func spanKey(pkg, test string) string {
+	if test == "" {
+		return pkg
+	}
+	return pkg + "/" + test
+}
+
+// RunGoTest executes `go test` with JSON output and creates spans for each test.
+// It returns the combined output and any error from the test execution.
+func (t *GoTestTracer) RunGoTest(ctx context.Context, env []string, cwd string, testArgs []string, outputWriter io.Writer) error {
+	if t.tracer == nil {
+		// No tracer configured, fall back to regular execution
+		return runGoTestWithoutTracing(env, cwd, testArgs, outputWriter)
+	}
+
+	// Ensure -json flag is present
+	args := ensureJSONFlag(testArgs)
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Dir = cwd
+	cmd.Env = env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	// Capture stderr separately
+	cmd.Stderr = outputWriter
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start go test: %w", err)
+	}
+
+	// Parse JSON output and create spans
+	if err := t.parseJSONOutput(stdout, outputWriter); err != nil {
+		log.WithError(err).Warn("error parsing go test JSON output")
+	}
+
+	// Wait for command to complete
+	return cmd.Wait()
+}
+
+// parseJSONOutput reads JSON events from the reader and creates/ends spans accordingly
+func (t *GoTestTracer) parseJSONOutput(r io.Reader, outputWriter io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	// Increase buffer size for long output lines
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		var event goTestEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			// Not valid JSON, write as-is (shouldn't happen with -json flag)
+			if outputWriter != nil {
+				_, _ = outputWriter.Write(line)
+				_, _ = outputWriter.Write([]byte("\n"))
+			}
+			continue
+		}
+
+		// Write the output to the reporter
+		if outputWriter != nil && event.Output != "" {
+			_, _ = outputWriter.Write([]byte(event.Output))
+		}
+
+		// Handle the event
+		t.handleEvent(&event)
+	}
+
+	// End any remaining spans (in case of abnormal termination)
+	t.endAllSpans()
+
+	return scanner.Err()
+}
+
+// handleEvent processes a single go test event
+func (t *GoTestTracer) handleEvent(event *goTestEvent) {
+	switch event.Action {
+	case "run":
+		t.handleRun(event)
+	case "pause":
+		t.handlePause(event)
+	case "cont":
+		t.handleCont(event)
+	case "pass", "fail", "skip":
+		t.handleEnd(event)
+	case "output":
+		// Output is already written to outputWriter
+	case "start":
+		// Package test started - we could create a package-level span here
+		t.handlePackageStart(event)
+	}
+}
+
+// handleRun creates a new span for a test that started running
+func (t *GoTestTracer) handleRun(event *goTestEvent) {
+	if event.Test == "" || t.tracer == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := spanKey(event.Package, event.Test)
+
+	// Create span with the test start time
+	_, span := t.tracer.Start(t.parentCtx, formatTestSpanName(event.Package, event.Test),
+		trace.WithTimestamp(event.Time),
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+
+	span.SetAttributes(
+		attribute.String("test.name", event.Test),
+		attribute.String("test.package", event.Package),
+		attribute.String("test.framework", "go"),
+	)
+
+	t.spans[key] = &testSpanData{
+		span:      span,
+		startTime: event.Time,
+		pkg:       event.Package,
+	}
+}
+
+// handlePackageStart creates a span for package-level test execution
+func (t *GoTestTracer) handlePackageStart(event *goTestEvent) {
+	if event.Package == "" || t.tracer == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := spanKey(event.Package, "")
+
+	// Only create if not already exists
+	if _, exists := t.spans[key]; exists {
+		return
+	}
+
+	_, span := t.tracer.Start(t.parentCtx, fmt.Sprintf("package: %s", event.Package),
+		trace.WithTimestamp(event.Time),
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+
+	span.SetAttributes(
+		attribute.String("test.package", event.Package),
+		attribute.String("test.framework", "go"),
+		attribute.String("test.scope", "package"),
+	)
+
+	t.spans[key] = &testSpanData{
+		span:      span,
+		startTime: event.Time,
+		pkg:       event.Package,
+	}
+}
+
+// handlePause records that a test was paused (for t.Parallel())
+func (t *GoTestTracer) handlePause(event *goTestEvent) {
+	if event.Test == "" {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := spanKey(event.Package, event.Test)
+	if data, ok := t.spans[key]; ok {
+		data.span.AddEvent("test.paused", trace.WithTimestamp(event.Time))
+	}
+}
+
+// handleCont records that a paused test continued
+func (t *GoTestTracer) handleCont(event *goTestEvent) {
+	if event.Test == "" {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := spanKey(event.Package, event.Test)
+	if data, ok := t.spans[key]; ok {
+		data.span.AddEvent("test.continued", trace.WithTimestamp(event.Time))
+	}
+}
+
+// handleEnd ends a span for a completed test
+func (t *GoTestTracer) handleEnd(event *goTestEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Handle test-level completion
+	if event.Test != "" {
+		key := spanKey(event.Package, event.Test)
+		if data, ok := t.spans[key]; ok {
+			// Set status based on action
+			switch event.Action {
+			case "pass":
+				data.span.SetStatus(codes.Ok, "")
+				data.span.SetAttributes(attribute.String("test.status", "passed"))
+			case "fail":
+				data.span.SetStatus(codes.Error, "test failed")
+				data.span.SetAttributes(attribute.String("test.status", "failed"))
+			case "skip":
+				data.span.SetStatus(codes.Ok, "test skipped")
+				data.span.SetAttributes(attribute.String("test.status", "skipped"))
+			}
+
+			// Add elapsed time if available
+			if event.Elapsed > 0 {
+				data.span.SetAttributes(attribute.Float64("test.elapsed_seconds", event.Elapsed))
+			}
+
+			data.span.End(trace.WithTimestamp(event.Time))
+			delete(t.spans, key)
+		}
+		return
+	}
+
+	// Handle package-level completion (event.Test is empty)
+	if event.Package != "" {
+		key := spanKey(event.Package, "")
+		if data, ok := t.spans[key]; ok {
+			switch event.Action {
+			case "pass":
+				data.span.SetStatus(codes.Ok, "")
+				data.span.SetAttributes(attribute.String("test.status", "passed"))
+			case "fail":
+				data.span.SetStatus(codes.Error, "package tests failed")
+				data.span.SetAttributes(attribute.String("test.status", "failed"))
+			case "skip":
+				data.span.SetStatus(codes.Ok, "package tests skipped")
+				data.span.SetAttributes(attribute.String("test.status", "skipped"))
+			}
+
+			if event.Elapsed > 0 {
+				data.span.SetAttributes(attribute.Float64("test.elapsed_seconds", event.Elapsed))
+			}
+
+			data.span.End(trace.WithTimestamp(event.Time))
+			delete(t.spans, key)
+		}
+	}
+}
+
+// endAllSpans ends any remaining open spans (cleanup for abnormal termination)
+func (t *GoTestTracer) endAllSpans() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for key, data := range t.spans {
+		data.span.SetStatus(codes.Error, "test did not complete")
+		data.span.End()
+		delete(t.spans, key)
+	}
+}
+
+// formatTestSpanName creates a readable span name for a test
+func formatTestSpanName(pkg, test string) string {
+	// Extract just the package name without the full module path
+	parts := strings.Split(pkg, "/")
+	shortPkg := parts[len(parts)-1]
+
+	return fmt.Sprintf("test: %s/%s", shortPkg, test)
+}
+
+// ensureJSONFlag ensures the -json flag is present in the test arguments
+func ensureJSONFlag(args []string) []string {
+	for _, arg := range args {
+		if arg == "-json" {
+			return args
+		}
+	}
+
+	// Insert -json after "test" command
+	result := make([]string, 0, len(args)+1)
+	for i, arg := range args {
+		result = append(result, arg)
+		if arg == "test" && i < len(args)-1 {
+			result = append(result, "-json")
+		}
+	}
+
+	// If "test" wasn't found, just append -json
+	hasJSON := false
+	for _, arg := range result {
+		if arg == "-json" {
+			hasJSON = true
+			break
+		}
+	}
+	if !hasJSON {
+		result = append(result, "-json")
+	}
+
+	return result
+}
+
+// runGoTestWithoutTracing runs go test without JSON parsing (fallback)
+func runGoTestWithoutTracing(env []string, cwd string, testArgs []string, outputWriter io.Writer) error {
+	cmd := exec.Command(testArgs[0], testArgs[1:]...)
+	cmd.Dir = cwd
+	cmd.Env = env
+	cmd.Stdout = outputWriter
+	cmd.Stderr = outputWriter
+	return cmd.Run()
+}

--- a/pkg/leeway/gotest_trace.go
+++ b/pkg/leeway/gotest_trace.go
@@ -27,11 +27,9 @@ type goTestEvent struct {
 	Elapsed float64   `json:"Elapsed"` // seconds
 }
 
-// testSpanData holds the span and metadata for an in-progress test
+// testSpanData holds the span for an in-progress test
 type testSpanData struct {
-	span      trace.Span
-	startTime time.Time
-	pkg       string
+	span trace.Span
 }
 
 // GoTestTracer handles parsing Go test JSON output and creating OpenTelemetry spans
@@ -169,11 +167,7 @@ func (t *GoTestTracer) handleRun(event *goTestEvent) {
 		attribute.String("test.framework", "go"),
 	)
 
-	t.spans[key] = &testSpanData{
-		span:      span,
-		startTime: event.Time,
-		pkg:       event.Package,
-	}
+	t.spans[key] = &testSpanData{span: span}
 }
 
 // handlePackageStart creates a span for package-level test execution
@@ -203,11 +197,7 @@ func (t *GoTestTracer) handlePackageStart(event *goTestEvent) {
 		attribute.String("test.scope", "package"),
 	)
 
-	t.spans[key] = &testSpanData{
-		span:      span,
-		startTime: event.Time,
-		pkg:       event.Package,
-	}
+	t.spans[key] = &testSpanData{span: span}
 }
 
 // handlePause records that a test was paused (for t.Parallel())

--- a/pkg/leeway/gotest_trace.go
+++ b/pkg/leeway/gotest_trace.go
@@ -78,15 +78,13 @@ func (t *GoTestTracer) parseJSONOutput(r io.Reader, outputWriter io.Writer) erro
 		var event goTestEvent
 		if err := json.Unmarshal(line, &event); err != nil {
 			// Not valid JSON, write as-is (shouldn't happen with -json flag)
-			if outputWriter != nil {
-				_, _ = outputWriter.Write(line)
-				_, _ = outputWriter.Write([]byte("\n"))
-			}
+			_, _ = outputWriter.Write(line)
+			_, _ = outputWriter.Write([]byte("\n"))
 			continue
 		}
 
 		// Handle output based on verbosity
-		if outputWriter != nil && event.Output != "" {
+		if event.Output != "" {
 			if verbose {
 				// Verbose mode: show all output
 				_, _ = outputWriter.Write([]byte(event.Output))

--- a/pkg/leeway/gotest_trace_test.go
+++ b/pkg/leeway/gotest_trace_test.go
@@ -33,9 +33,12 @@ func TestGoTestTracer_ParseJSONOutput(t *testing.T) {
 {"Time":"2024-01-01T10:00:00.100Z","Action":"output","Package":"example.com/pkg","Test":"TestOne","Output":"--- PASS: TestOne (0.10s)\n"}
 {"Time":"2024-01-01T10:00:00.100Z","Action":"pass","Package":"example.com/pkg","Test":"TestOne","Elapsed":0.1}
 {"Time":"2024-01-01T10:00:00.101Z","Action":"run","Package":"example.com/pkg","Test":"TestTwo"}
+{"Time":"2024-01-01T10:00:00.150Z","Action":"output","Package":"example.com/pkg","Test":"TestTwo","Output":"    test_two.go:10: assertion failed\n"}
 {"Time":"2024-01-01T10:00:00.200Z","Action":"fail","Package":"example.com/pkg","Test":"TestTwo","Elapsed":0.1}
 {"Time":"2024-01-01T10:00:00.201Z","Action":"run","Package":"example.com/pkg","Test":"TestThree"}
 {"Time":"2024-01-01T10:00:00.250Z","Action":"skip","Package":"example.com/pkg","Test":"TestThree","Elapsed":0.05}
+{"Time":"2024-01-01T10:00:00.299Z","Action":"output","Package":"example.com/pkg","Output":"PASS\n"}
+{"Time":"2024-01-01T10:00:00.300Z","Action":"output","Package":"example.com/pkg","Output":"ok  \texample.com/pkg\t0.3s\n"}
 {"Time":"2024-01-01T10:00:00.300Z","Action":"pass","Package":"example.com/pkg","Elapsed":0.3}
 `
 
@@ -99,8 +102,13 @@ func TestGoTestTracer_ParseJSONOutput(t *testing.T) {
 
 	// Verify output was written
 	output := outputBuf.String()
-	if !strings.Contains(output, "=== RUN   TestOne") {
-		t.Error("expected test output to be written")
+	// Package-level output should always be shown
+	if !strings.Contains(output, "ok  \texample.com/pkg") {
+		t.Error("expected package summary output to be written")
+	}
+	// Failed test output should be shown (TestTwo failed)
+	if !strings.Contains(output, "assertion failed") {
+		t.Error("expected failed test output to be written")
 	}
 }
 

--- a/pkg/leeway/gotest_trace_test.go
+++ b/pkg/leeway/gotest_trace_test.go
@@ -1,0 +1,280 @@
+package leeway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestGoTestTracer_ParseJSONOutput(t *testing.T) {
+	// Create a test tracer provider with in-memory exporter
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exporter),
+	)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	tracer := tp.Tracer("test")
+	ctx, parentSpan := tracer.Start(context.Background(), "parent")
+	defer parentSpan.End()
+
+	goTracer := NewGoTestTracer(tracer, ctx)
+
+	// Simulate go test -json output
+	jsonOutput := `{"Time":"2024-01-01T10:00:00Z","Action":"start","Package":"example.com/pkg"}
+{"Time":"2024-01-01T10:00:00.001Z","Action":"run","Package":"example.com/pkg","Test":"TestOne"}
+{"Time":"2024-01-01T10:00:00.002Z","Action":"output","Package":"example.com/pkg","Test":"TestOne","Output":"=== RUN   TestOne\n"}
+{"Time":"2024-01-01T10:00:00.100Z","Action":"output","Package":"example.com/pkg","Test":"TestOne","Output":"--- PASS: TestOne (0.10s)\n"}
+{"Time":"2024-01-01T10:00:00.100Z","Action":"pass","Package":"example.com/pkg","Test":"TestOne","Elapsed":0.1}
+{"Time":"2024-01-01T10:00:00.101Z","Action":"run","Package":"example.com/pkg","Test":"TestTwo"}
+{"Time":"2024-01-01T10:00:00.200Z","Action":"fail","Package":"example.com/pkg","Test":"TestTwo","Elapsed":0.1}
+{"Time":"2024-01-01T10:00:00.201Z","Action":"run","Package":"example.com/pkg","Test":"TestThree"}
+{"Time":"2024-01-01T10:00:00.250Z","Action":"skip","Package":"example.com/pkg","Test":"TestThree","Elapsed":0.05}
+{"Time":"2024-01-01T10:00:00.300Z","Action":"pass","Package":"example.com/pkg","Elapsed":0.3}
+`
+
+	var outputBuf bytes.Buffer
+	err := goTracer.parseJSONOutput(strings.NewReader(jsonOutput), &outputBuf)
+	if err != nil {
+		t.Fatalf("parseJSONOutput failed: %v", err)
+	}
+
+	// End parent span to flush
+	parentSpan.End()
+
+	// Check that spans were created
+	spans := exporter.GetSpans()
+
+	// We expect: parent span + package span + 3 test spans = 5 spans
+	// But the parent span is ended after, so we check for at least 4
+	if len(spans) < 4 {
+		t.Errorf("expected at least 4 spans, got %d", len(spans))
+		for i, s := range spans {
+			t.Logf("span %d: %s", i, s.Name)
+		}
+	}
+
+	// Verify test spans exist with correct names
+	spanNames := make(map[string]bool)
+	for _, s := range spans {
+		spanNames[s.Name] = true
+	}
+
+	expectedSpans := []string{
+		"test: pkg/TestOne",
+		"test: pkg/TestTwo",
+		"test: pkg/TestThree",
+		"package: example.com/pkg",
+	}
+
+	for _, expected := range expectedSpans {
+		if !spanNames[expected] {
+			t.Errorf("expected span %q not found", expected)
+		}
+	}
+
+	// Verify span statuses
+	for _, s := range spans {
+		switch s.Name {
+		case "test: pkg/TestOne":
+			if s.Status.Code != codes.Ok {
+				t.Errorf("TestOne should have Ok status, got %v", s.Status.Code)
+			}
+		case "test: pkg/TestTwo":
+			if s.Status.Code != codes.Error {
+				t.Errorf("TestTwo should have Error status, got %v", s.Status.Code)
+			}
+		case "test: pkg/TestThree":
+			if s.Status.Code != codes.Ok {
+				t.Errorf("TestThree (skipped) should have Ok status, got %v", s.Status.Code)
+			}
+		}
+	}
+
+	// Verify output was written
+	output := outputBuf.String()
+	if !strings.Contains(output, "=== RUN   TestOne") {
+		t.Error("expected test output to be written")
+	}
+}
+
+func TestGoTestTracer_ParallelTests(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exporter),
+	)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	tracer := tp.Tracer("test")
+	ctx, parentSpan := tracer.Start(context.Background(), "parent")
+	defer parentSpan.End()
+
+	goTracer := NewGoTestTracer(tracer, ctx)
+
+	// Simulate parallel test execution with pause/cont events
+	jsonOutput := `{"Time":"2024-01-01T10:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestParallel"}
+{"Time":"2024-01-01T10:00:00.001Z","Action":"pause","Package":"example.com/pkg","Test":"TestParallel"}
+{"Time":"2024-01-01T10:00:00.100Z","Action":"cont","Package":"example.com/pkg","Test":"TestParallel"}
+{"Time":"2024-01-01T10:00:00.200Z","Action":"pass","Package":"example.com/pkg","Test":"TestParallel","Elapsed":0.2}
+`
+
+	var outputBuf bytes.Buffer
+	err := goTracer.parseJSONOutput(strings.NewReader(jsonOutput), &outputBuf)
+	if err != nil {
+		t.Fatalf("parseJSONOutput failed: %v", err)
+	}
+
+	parentSpan.End()
+	spans := exporter.GetSpans()
+
+	// Find the test span
+	var testSpan *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == "test: pkg/TestParallel" {
+			testSpan = &spans[i]
+			break
+		}
+	}
+
+	if testSpan == nil {
+		t.Fatal("TestParallel span not found")
+	}
+
+	// Verify pause and cont events were recorded
+	eventNames := make([]string, 0)
+	for _, e := range testSpan.Events {
+		eventNames = append(eventNames, e.Name)
+	}
+
+	if len(eventNames) != 2 {
+		t.Errorf("expected 2 events (pause, cont), got %d: %v", len(eventNames), eventNames)
+	}
+}
+
+func TestGoTestTracer_NoTracer(t *testing.T) {
+	// Test that nil tracer doesn't panic
+	goTracer := NewGoTestTracer(nil, context.Background())
+
+	jsonOutput := `{"Time":"2024-01-01T10:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestOne"}
+{"Time":"2024-01-01T10:00:00.100Z","Action":"pass","Package":"example.com/pkg","Test":"TestOne","Elapsed":0.1}
+`
+
+	var outputBuf bytes.Buffer
+	err := goTracer.parseJSONOutput(strings.NewReader(jsonOutput), &outputBuf)
+	if err != nil {
+		t.Fatalf("parseJSONOutput failed: %v", err)
+	}
+}
+
+func TestEnsureJSONFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "already has -json",
+			input:    []string{"go", "test", "-json", "./..."},
+			expected: []string{"go", "test", "-json", "./..."},
+		},
+		{
+			name:     "needs -json after test",
+			input:    []string{"go", "test", "-v", "./..."},
+			expected: []string{"go", "test", "-json", "-v", "./..."},
+		},
+		{
+			name:     "simple test command",
+			input:    []string{"go", "test"},
+			expected: []string{"go", "test", "-json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureJSONFlag(tt.input)
+
+			// Check that -json is present
+			hasJSON := false
+			for _, arg := range result {
+				if arg == "-json" {
+					hasJSON = true
+					break
+				}
+			}
+			if !hasJSON {
+				t.Errorf("result %v does not contain -json", result)
+			}
+		})
+	}
+}
+
+func TestSpanKey(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		test     string
+		expected string
+	}{
+		{"example.com/pkg", "TestOne", "example.com/pkg/TestOne"},
+		{"example.com/pkg", "", "example.com/pkg"},
+		{"pkg", "TestSub/case1", "pkg/TestSub/case1"},
+	}
+
+	for _, tt := range tests {
+		result := spanKey(tt.pkg, tt.test)
+		if result != tt.expected {
+			t.Errorf("spanKey(%q, %q) = %q, want %q", tt.pkg, tt.test, result, tt.expected)
+		}
+	}
+}
+
+func TestFormatTestSpanName(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		test     string
+		expected string
+	}{
+		{"example.com/pkg", "TestOne", "test: pkg/TestOne"},
+		{"github.com/org/repo/internal/service", "TestCreate", "test: service/TestCreate"},
+		{"simple", "TestSimple", "test: simple/TestSimple"},
+	}
+
+	for _, tt := range tests {
+		result := formatTestSpanName(tt.pkg, tt.test)
+		if result != tt.expected {
+			t.Errorf("formatTestSpanName(%q, %q) = %q, want %q", tt.pkg, tt.test, result, tt.expected)
+		}
+	}
+}
+
+func TestGoTestEvent_Parsing(t *testing.T) {
+	// Test that goTestEvent can parse real go test -json output
+	jsonLine := `{"Time":"2024-01-15T10:30:45.123456789Z","Action":"pass","Package":"github.com/example/pkg","Test":"TestExample","Elapsed":1.234}`
+
+	var event goTestEvent
+	err := json.Unmarshal([]byte(jsonLine), &event)
+	if err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if event.Action != "pass" {
+		t.Errorf("expected action 'pass', got %q", event.Action)
+	}
+	if event.Package != "github.com/example/pkg" {
+		t.Errorf("expected package 'github.com/example/pkg', got %q", event.Package)
+	}
+	if event.Test != "TestExample" {
+		t.Errorf("expected test 'TestExample', got %q", event.Test)
+	}
+	if event.Elapsed != 1.234 {
+		t.Errorf("expected elapsed 1.234, got %f", event.Elapsed)
+	}
+	if event.Time.IsZero() {
+		t.Error("expected non-zero time")
+	}
+}

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -554,7 +554,21 @@ func (cr CompositeReporter) PackageBuildStarted(pkg *Package, builddir string) {
 	}
 }
 
+// GetGoTestTracer implements TestTracingReporter by delegating to the first
+// wrapped reporter that supports test tracing.
+func (cr CompositeReporter) GetGoTestTracer(pkg *Package) *GoTestTracer {
+	for _, r := range cr {
+		if tr, ok := r.(TestTracingReporter); ok {
+			if tracer := tr.GetGoTestTracer(pkg); tracer != nil {
+				return tracer
+			}
+		}
+	}
+	return nil
+}
+
 var _ Reporter = CompositeReporter{}
+var _ TestTracingReporter = CompositeReporter{}
 
 type NoopReporter struct{}
 


### PR DESCRIPTION
## Description

Add per-test OpenTelemetry spans during Go package builds. When tracing is enabled, leeway parses `go test -json` output and creates child spans for each test under the package span. This provides visibility into individual test duration and parallelism in build traces.

Can be enabled by passing the `--enable-test-tracing` flag, disabled by default

<img width="1664" height="1183" alt="image" src="https://github.com/user-attachments/assets/9ab61a58-63cf-4a9d-9d77-9385cb5adfa2" />

https://ui.honeycomb.io/gitpod/environments/ci/datasets/leeway/result/FhLg2E7Cfp4/trace/8cAj6RnnZpf?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&fields%5B%5D=c_leeway.package.name&fields%5B%5D=c_leeway.package.last_phase&span=14df73420d330fac

<img width="1666" height="661" alt="image" src="https://github.com/user-attachments/assets/c6257031-3c18-408e-b976-6d328da5da3e" />

https://ui.honeycomb.io/gitpod/environments/ci/datasets/leeway/result/chTYCtKiNU8/trace/3gqNBXCwcwZ?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&fields%5B%5D=c_leeway.package.name&fields%5B%5D=c_leeway.package.last_phase&span=2bc30322f9351793

## Related Issue(s)

Fixes CORE-6451

## How to test

1. Build a Go package with OpenTelemetry tracing enabled
2. View the trace in your collector (e.g., Jaeger)
3. Verify individual test spans appear as children of the package span with correct status (pass/fail/skip) and timing