### PR TITLE
feat: add nested phase spans for OpenTelemetry tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,25 @@ export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=YOUR_API_KEY"
 leeway build :my-package
 ```
 
+The OpenTelemetry SDK automatically reads standard `OTEL_EXPORTER_OTLP_*` environment variables.
+
+## Span Hierarchy
+
+Leeway creates a nested span hierarchy for detailed build timeline visualization:
+
+```
+leeway.build (root)
+├── leeway.package (component:package-1)
+│   ├── leeway.phase (prep)
+│   ├── leeway.phase (build)
+│   └── leeway.phase (test)
+└── leeway.package (component:package-2)
+    ├── leeway.phase (prep)
+    └── leeway.phase (build)
+```
+
+Each phase span captures timing, status, and errors for individual build phases (prep, pull, lint, test, build, package).
+
 See [docs/observability.md](docs/observability.md) for configuration, examples, and span attributes.
 
 # Provenance (SLSA) - EXPERIMENTAL

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -3170,7 +3170,7 @@ func runGoTestWithTracing(buildctx *buildContext, p *Package, env []string, cwd,
 	}
 
 	// Create tracer and parse output
-	goTracer := NewGoTestTracer(tracer, parentCtx)
+	goTracer := NewGoTestTracer(tracer, parentCtx, p.FullName())
 	outputWriter := &reporterStream{R: buildctx.Reporter, P: p, IsErr: false}
 
 	if err := goTracer.parseJSONOutput(stdout, outputWriter); err != nil {

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -1365,6 +1365,11 @@ func executeBuildPhase(buildctx *buildContext, p *Package, builddir string, bld 
 		return nil
 	}
 
+	// Notify phase-aware reporters
+	if par, ok := buildctx.Reporter.(PhaseAwareReporter); ok {
+		par.PackageBuildPhaseStarted(p, phase)
+	}
+
 	if phase != PackageBuildPhasePrep {
 		pkgRep.phaseEnter[phase] = time.Now()
 		pkgRep.Phases = append(pkgRep.Phases, phase)
@@ -1374,6 +1379,11 @@ func executeBuildPhase(buildctx *buildContext, p *Package, builddir string, bld 
 
 	err := executeCommandsForPackage(buildctx, p, builddir, cmds)
 	pkgRep.phaseDone[phase] = time.Now()
+
+	// Notify phase-aware reporters
+	if par, ok := buildctx.Reporter.(PhaseAwareReporter); ok {
+		par.PackageBuildPhaseFinished(p, phase, err)
+	}
 
 	return err
 }

--- a/pkg/leeway/gotest_trace_test.go
+++ b/pkg/leeway/gotest_trace_test.go
@@ -24,7 +24,7 @@ func TestGoTestTracer_ParseJSONOutput(t *testing.T) {
 	ctx, parentSpan := tracer.Start(context.Background(), "parent")
 	defer parentSpan.End()
 
-	goTracer := NewGoTestTracer(tracer, ctx)
+	goTracer := NewGoTestTracer(tracer, ctx, "test:pkg")
 
 	// Simulate go test -json output
 	jsonOutput := `{"Time":"2024-01-01T10:00:00Z","Action":"start","Package":"example.com/pkg"}
@@ -123,7 +123,7 @@ func TestGoTestTracer_ParallelTests(t *testing.T) {
 	ctx, parentSpan := tracer.Start(context.Background(), "parent")
 	defer parentSpan.End()
 
-	goTracer := NewGoTestTracer(tracer, ctx)
+	goTracer := NewGoTestTracer(tracer, ctx, "test:pkg")
 
 	// Simulate parallel test execution with pause/cont events
 	jsonOutput := `{"Time":"2024-01-01T10:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestParallel"}
@@ -167,7 +167,7 @@ func TestGoTestTracer_ParallelTests(t *testing.T) {
 
 func TestGoTestTracer_NoTracer(t *testing.T) {
 	// Test that nil tracer doesn't panic
-	goTracer := NewGoTestTracer(nil, context.Background())
+	goTracer := NewGoTestTracer(nil, context.Background(), "test:pkg")
 
 	jsonOutput := `{"Time":"2024-01-01T10:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestOne"}
 {"Time":"2024-01-01T10:00:00.100Z","Action":"pass","Package":"example.com/pkg","Test":"TestOne","Elapsed":0.1}

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -941,7 +941,7 @@ func (r *OTelReporter) PackageBuildPhaseStarted(pkg *Package, phase PackageBuild
 
 	// Create phase span as child of package span
 	phaseKey := fmt.Sprintf("%s:%s", pkgName, phase)
-	ctx, span := r.tracer.Start(packageCtx, "leeway.phase",
+	_, span := r.tracer.Start(packageCtx, "leeway.phase",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 
@@ -950,9 +950,7 @@ func (r *OTelReporter) PackageBuildPhaseStarted(pkg *Package, phase PackageBuild
 		attribute.String("leeway.phase.name", string(phase)),
 	)
 
-	// Store phase span and update package context
 	r.phaseSpans[phaseKey] = span
-	r.packageCtxs[pkgName] = ctx
 }
 
 // PackageBuildPhaseFinished implements PhaseAwareReporter

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -949,6 +949,7 @@ func (r *OTelReporter) PackageBuildPhaseStarted(pkg *Package, phase PackageBuild
 
 	// Add phase attributes
 	span.SetAttributes(
+		attribute.String("leeway.package.name", pkgName),
 		attribute.String("leeway.phase.name", string(phase)),
 	)
 

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -555,7 +555,26 @@ func (cr CompositeReporter) PackageBuildStarted(pkg *Package, builddir string) {
 	}
 }
 
+// PackageBuildPhaseStarted implements PhaseAwareReporter
+func (cr CompositeReporter) PackageBuildPhaseStarted(pkg *Package, phase PackageBuildPhase) {
+	for _, r := range cr {
+		if par, ok := r.(PhaseAwareReporter); ok {
+			par.PackageBuildPhaseStarted(pkg, phase)
+		}
+	}
+}
+
+// PackageBuildPhaseFinished implements PhaseAwareReporter
+func (cr CompositeReporter) PackageBuildPhaseFinished(pkg *Package, phase PackageBuildPhase, err error) {
+	for _, r := range cr {
+		if par, ok := r.(PhaseAwareReporter); ok {
+			par.PackageBuildPhaseFinished(pkg, phase, err)
+		}
+	}
+}
+
 var _ Reporter = CompositeReporter{}
+var _ PhaseAwareReporter = CompositeReporter{}
 
 type NoopReporter struct{}
 

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -52,6 +52,17 @@ type Reporter interface {
 	PackageBuildFinished(pkg *Package, rep *PackageBuildReport)
 }
 
+// PhaseAwareReporter is an optional interface that reporters can implement
+// to receive phase-level notifications for creating nested spans or tracking.
+// This follows the Go pattern of optional interfaces (like io.Closer, io.Seeker).
+type PhaseAwareReporter interface {
+	Reporter
+	// PackageBuildPhaseStarted is called when a build phase starts
+	PackageBuildPhaseStarted(pkg *Package, phase PackageBuildPhase)
+	// PackageBuildPhaseFinished is called when a build phase completes
+	PackageBuildPhaseFinished(pkg *Package, phase PackageBuildPhase, err error)
+}
+
 type PackageBuildReport struct {
 	phaseEnter map[PackageBuildPhase]time.Time
 	phaseDone  map[PackageBuildPhase]time.Time
@@ -701,6 +712,7 @@ type OTelReporter struct {
 	rootSpan     trace.Span
 	packageCtxs  map[string]context.Context
 	packageSpans map[string]trace.Span
+	phaseSpans   map[string]trace.Span // key: "packageName:phaseName"
 	mu           sync.RWMutex
 }
 
@@ -714,6 +726,7 @@ func NewOTelReporter(tracer trace.Tracer, parentCtx context.Context) *OTelReport
 		parentCtx:    parentCtx,
 		packageCtxs:  make(map[string]context.Context),
 		packageSpans: make(map[string]trace.Span),
+		phaseSpans:   make(map[string]trace.Span),
 	}
 }
 
@@ -866,16 +879,6 @@ func (r *OTelReporter) PackageBuildFinished(pkg *Package, rep *PackageBuildRepor
 		attribute.Int64("leeway.package.duration_ms", rep.TotalTime().Milliseconds()),
 	)
 
-	// Add phase durations
-	for _, phase := range rep.Phases {
-		duration := rep.PhaseDuration(phase)
-		if duration >= 0 {
-			span.SetAttributes(
-				attribute.Int64(fmt.Sprintf("leeway.package.phase.%s.duration_ms", phase), duration.Milliseconds()),
-			)
-		}
-	}
-
 	// Add test coverage if available
 	if rep.TestCoverageAvailable {
 		span.SetAttributes(
@@ -899,6 +902,70 @@ func (r *OTelReporter) PackageBuildFinished(pkg *Package, rep *PackageBuildRepor
 	// Clean up
 	delete(r.packageSpans, pkgName)
 	delete(r.packageCtxs, pkgName)
+}
+
+// PackageBuildPhaseStarted implements PhaseAwareReporter
+func (r *OTelReporter) PackageBuildPhaseStarted(pkg *Package, phase PackageBuildPhase) {
+	if r.tracer == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pkgName := pkg.FullName()
+	packageCtx, ok := r.packageCtxs[pkgName]
+	if !ok {
+		log.WithField("package", pkgName).Warn("PackageBuildPhaseStarted called without package context")
+		return
+	}
+
+	// Create phase span as child of package span
+	phaseKey := fmt.Sprintf("%s:%s", pkgName, phase)
+	ctx, span := r.tracer.Start(packageCtx, "leeway.phase",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+
+	// Add phase attributes
+	span.SetAttributes(
+		attribute.String("leeway.phase.name", string(phase)),
+	)
+
+	// Store phase span and update package context
+	r.phaseSpans[phaseKey] = span
+	r.packageCtxs[pkgName] = ctx
+}
+
+// PackageBuildPhaseFinished implements PhaseAwareReporter
+func (r *OTelReporter) PackageBuildPhaseFinished(pkg *Package, phase PackageBuildPhase, err error) {
+	if r.tracer == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pkgName := pkg.FullName()
+	phaseKey := fmt.Sprintf("%s:%s", pkgName, phase)
+	span, ok := r.phaseSpans[phaseKey]
+	if !ok {
+		log.WithField("package", pkgName).WithField("phase", phase).Warn("PackageBuildPhaseFinished called without corresponding PackageBuildPhaseStarted")
+		return
+	}
+
+	// Set error status if phase failed
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "phase completed successfully")
+	}
+
+	// End span
+	span.End()
+
+	// Clean up
+	delete(r.phaseSpans, phaseKey)
 }
 
 // addGitHubAttributes adds GitHub Actions context attributes to the span

--- a/pkg/leeway/reporter_otel_phase_test.go
+++ b/pkg/leeway/reporter_otel_phase_test.go
@@ -1,0 +1,329 @@
+package leeway
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestOTelReporter_PhaseSpans(t *testing.T) {
+	// Create in-memory exporter for testing
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(
+		trace.WithSyncer(exporter),
+	)
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	tracer := tp.Tracer("test")
+	reporter := NewOTelReporter(tracer, context.Background())
+
+	// Create test package
+	pkg := &Package{
+		C: &Component{
+			Name: "test-component",
+			W: &Workspace{
+				Origin: "/workspace",
+			},
+		},
+		PackageInternal: PackageInternal{
+			Name: "test-package",
+			Type: GenericPackage,
+		},
+	}
+
+	// Start build and package
+	status := map[*Package]PackageBuildStatus{
+		pkg: PackageNotBuiltYet,
+	}
+	reporter.BuildStarted(pkg, status)
+	reporter.PackageBuildStarted(pkg, "/tmp/build")
+
+	// Simulate phase execution
+	phases := []PackageBuildPhase{
+		PackageBuildPhasePrep,
+		PackageBuildPhaseBuild,
+		PackageBuildPhaseTest,
+	}
+
+	for _, phase := range phases {
+		reporter.PackageBuildPhaseStarted(pkg, phase)
+		time.Sleep(10 * time.Millisecond) // Simulate work
+		reporter.PackageBuildPhaseFinished(pkg, phase, nil)
+	}
+
+	// Finish package and build
+	rep := &PackageBuildReport{
+		phaseEnter: make(map[PackageBuildPhase]time.Time),
+		phaseDone:  make(map[PackageBuildPhase]time.Time),
+		Phases:     phases,
+		Error:      nil,
+	}
+	reporter.PackageBuildFinished(pkg, rep)
+	reporter.BuildFinished(pkg, nil)
+
+	// Verify spans were created
+	spans := exporter.GetSpans()
+	if len(spans) < 5 { // build + package + 3 phases
+		t.Fatalf("Expected at least 5 spans (build + package + 3 phases), got %d", len(spans))
+	}
+
+	// Count phase spans
+	phaseSpanCount := 0
+	for _, span := range spans {
+		if span.Name == "leeway.phase" {
+			phaseSpanCount++
+
+			// Verify phase has name attribute
+			hasPhaseNameAttr := false
+			for _, attr := range span.Attributes {
+				if string(attr.Key) == "leeway.phase.name" {
+					hasPhaseNameAttr = true
+					phaseName := attr.Value.AsString()
+					if phaseName != string(PackageBuildPhasePrep) &&
+						phaseName != string(PackageBuildPhaseBuild) &&
+						phaseName != string(PackageBuildPhaseTest) {
+						t.Errorf("Unexpected phase name: %s", phaseName)
+					}
+				}
+			}
+			if !hasPhaseNameAttr {
+				t.Error("Expected 'leeway.phase.name' attribute in phase span")
+			}
+
+			// Verify status is OK
+			if span.Status.Code != codes.Ok {
+				t.Errorf("Expected phase span status OK, got %v", span.Status.Code)
+			}
+		}
+	}
+
+	if phaseSpanCount != 3 {
+		t.Errorf("Expected 3 phase spans, got %d", phaseSpanCount)
+	}
+}
+
+func TestOTelReporter_PhaseSpanWithError(t *testing.T) {
+	// Create in-memory exporter for testing
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(
+		trace.WithSyncer(exporter),
+	)
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	tracer := tp.Tracer("test")
+	reporter := NewOTelReporter(tracer, context.Background())
+
+	// Create test package
+	pkg := &Package{
+		C: &Component{
+			Name: "test-component",
+			W: &Workspace{
+				Origin: "/workspace",
+			},
+		},
+		PackageInternal: PackageInternal{
+			Name: "test-package",
+			Type: GenericPackage,
+		},
+	}
+
+	// Start build and package
+	status := map[*Package]PackageBuildStatus{
+		pkg: PackageNotBuiltYet,
+	}
+	reporter.BuildStarted(pkg, status)
+	reporter.PackageBuildStarted(pkg, "/tmp/build")
+
+	// Simulate phase with error
+	reporter.PackageBuildPhaseStarted(pkg, PackageBuildPhaseBuild)
+	buildErr := fmt.Errorf("build failed")
+	reporter.PackageBuildPhaseFinished(pkg, PackageBuildPhaseBuild, buildErr)
+
+	// Finish package and build
+	rep := &PackageBuildReport{
+		phaseEnter: make(map[PackageBuildPhase]time.Time),
+		phaseDone:  make(map[PackageBuildPhase]time.Time),
+		Phases:     []PackageBuildPhase{PackageBuildPhaseBuild},
+		Error:      buildErr,
+	}
+	reporter.PackageBuildFinished(pkg, rep)
+	reporter.BuildFinished(pkg, buildErr)
+
+	// Verify spans were created
+	spans := exporter.GetSpans()
+
+	// Find phase span
+	var phaseSpan *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == "leeway.phase" {
+			phaseSpan = &spans[i]
+			break
+		}
+	}
+
+	if phaseSpan == nil {
+		t.Fatal("Expected to find phase span")
+	}
+
+	// Verify error status
+	if phaseSpan.Status.Code != codes.Error {
+		t.Errorf("Expected phase span status Error, got %v", phaseSpan.Status.Code)
+	}
+
+	// Verify error was recorded
+	if len(phaseSpan.Events) == 0 {
+		t.Error("Expected error event to be recorded in phase span")
+	}
+}
+
+func TestOTelReporter_PhaseSpanHierarchy(t *testing.T) {
+	// Create in-memory exporter for testing
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(
+		trace.WithSyncer(exporter),
+	)
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	tracer := tp.Tracer("test")
+	reporter := NewOTelReporter(tracer, context.Background())
+
+	// Create test package
+	pkg := &Package{
+		C: &Component{
+			Name: "test-component",
+			W: &Workspace{
+				Origin: "/workspace",
+			},
+		},
+		PackageInternal: PackageInternal{
+			Name: "test-package",
+			Type: GenericPackage,
+		},
+	}
+
+	// Start build and package
+	status := map[*Package]PackageBuildStatus{
+		pkg: PackageNotBuiltYet,
+	}
+	reporter.BuildStarted(pkg, status)
+	reporter.PackageBuildStarted(pkg, "/tmp/build")
+
+	// Execute phase
+	reporter.PackageBuildPhaseStarted(pkg, PackageBuildPhaseBuild)
+	reporter.PackageBuildPhaseFinished(pkg, PackageBuildPhaseBuild, nil)
+
+	// Finish package and build
+	rep := &PackageBuildReport{
+		phaseEnter: make(map[PackageBuildPhase]time.Time),
+		phaseDone:  make(map[PackageBuildPhase]time.Time),
+		Phases:     []PackageBuildPhase{PackageBuildPhaseBuild},
+		Error:      nil,
+	}
+	reporter.PackageBuildFinished(pkg, rep)
+	reporter.BuildFinished(pkg, nil)
+
+	// Verify span hierarchy
+	spans := exporter.GetSpans()
+
+	var buildSpan, packageSpan, phaseSpan *tracetest.SpanStub
+	for i := range spans {
+		switch spans[i].Name {
+		case "leeway.build":
+			buildSpan = &spans[i]
+		case "leeway.package":
+			packageSpan = &spans[i]
+		case "leeway.phase":
+			phaseSpan = &spans[i]
+		}
+	}
+
+	if buildSpan == nil {
+		t.Fatal("Expected to find build span")
+	}
+	if packageSpan == nil {
+		t.Fatal("Expected to find package span")
+	}
+	if phaseSpan == nil {
+		t.Fatal("Expected to find phase span")
+	}
+
+	// Verify parent-child relationships
+	// Package span should be child of build span
+	if packageSpan.Parent.TraceID() != buildSpan.SpanContext.TraceID() {
+		t.Error("Package span should have same trace ID as build span")
+	}
+	if packageSpan.Parent.SpanID() != buildSpan.SpanContext.SpanID() {
+		t.Error("Package span should be child of build span")
+	}
+
+	// Phase span should be child of package span
+	if phaseSpan.Parent.TraceID() != packageSpan.SpanContext.TraceID() {
+		t.Error("Phase span should have same trace ID as package span")
+	}
+	if phaseSpan.Parent.SpanID() != packageSpan.SpanContext.SpanID() {
+		t.Error("Phase span should be child of package span")
+	}
+}
+
+func TestOTelReporter_PhaseAwareInterface(t *testing.T) {
+	// Verify OTelReporter implements PhaseAwareReporter
+	var _ PhaseAwareReporter = (*OTelReporter)(nil)
+
+	// Verify NoopReporter does NOT implement PhaseAwareReporter
+	var noop Reporter = &NoopReporter{}
+	if _, ok := noop.(PhaseAwareReporter); ok {
+		t.Error("NoopReporter should not implement PhaseAwareReporter")
+	}
+}
+
+func TestOTelReporter_PhaseWithoutPackageContext(t *testing.T) {
+	// Create in-memory exporter for testing
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(
+		trace.WithSyncer(exporter),
+	)
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	tracer := tp.Tracer("test")
+	reporter := NewOTelReporter(tracer, context.Background())
+
+	// Create test package
+	pkg := &Package{
+		C: &Component{
+			Name: "test-component",
+			W: &Workspace{
+				Origin: "/workspace",
+			},
+		},
+		PackageInternal: PackageInternal{
+			Name: "test-package",
+			Type: GenericPackage,
+		},
+	}
+
+	// Try to start phase without starting package first
+	// This should not panic and should log a warning
+	reporter.PackageBuildPhaseStarted(pkg, PackageBuildPhaseBuild)
+	reporter.PackageBuildPhaseFinished(pkg, PackageBuildPhaseBuild, nil)
+
+	// Verify no phase spans were created
+	spans := exporter.GetSpans()
+	for _, span := range spans {
+		if span.Name == "leeway.phase" {
+			t.Error("Phase span should not be created without package context")
+		}
+	}
+}

--- a/pkg/leeway/reporter_otel_test.go
+++ b/pkg/leeway/reporter_otel_test.go
@@ -820,6 +820,14 @@ func TestOTelReporter_PhaseDurations(t *testing.T) {
 	reporter.BuildStarted(pkg, status)
 	reporter.PackageBuildStarted(pkg, "/tmp/build")
 
+	// Simulate phase execution with actual phase spans
+	phases := []PackageBuildPhase{PackageBuildPhasePrep, PackageBuildPhaseBuild, PackageBuildPhaseTest}
+	for _, phase := range phases {
+		reporter.PackageBuildPhaseStarted(pkg, phase)
+		time.Sleep(10 * time.Millisecond) // Simulate work
+		reporter.PackageBuildPhaseFinished(pkg, phase, nil)
+	}
+
 	// Create report with phase durations
 	now := time.Now()
 	rep := &PackageBuildReport{
@@ -833,52 +841,41 @@ func TestOTelReporter_PhaseDurations(t *testing.T) {
 			PackageBuildPhaseBuild: now.Add(300 * time.Millisecond),
 			PackageBuildPhaseTest:  now.Add(500 * time.Millisecond),
 		},
-		Phases: []PackageBuildPhase{PackageBuildPhasePrep, PackageBuildPhaseBuild, PackageBuildPhaseTest},
+		Phases: phases,
 	}
 	reporter.PackageBuildFinished(pkg, rep)
 	reporter.BuildFinished(pkg, nil)
 
 	// Verify spans were created
 	spans := exporter.GetSpans()
-	if len(spans) < 2 {
-		t.Fatalf("Expected at least 2 spans, got %d", len(spans))
+	if len(spans) < 5 { // build + package + 3 phases
+		t.Fatalf("Expected at least 5 spans, got %d", len(spans))
 	}
 
-	// Find package span
-	var packageSpan *tracetest.SpanStub
-	for i := range spans {
-		if spans[i].Name == "leeway.package" {
-			packageSpan = &spans[i]
-			break
-		}
-	}
-
-	if packageSpan == nil {
-		t.Fatal("Expected to find package span")
-	}
-
-	// Verify phase duration attributes exist
+	// Verify phase spans exist (durations are now in nested spans, not attributes)
 	expectedPhases := []string{"prep", "build", "test"}
 	foundPhases := make(map[string]bool)
 
-	for _, attr := range packageSpan.Attributes {
-		key := string(attr.Key)
-		if strings.HasPrefix(key, "leeway.package.phase.") && strings.HasSuffix(key, ".duration_ms") {
-			phase := strings.TrimPrefix(key, "leeway.package.phase.")
-			phase = strings.TrimSuffix(phase, ".duration_ms")
-			foundPhases[phase] = true
+	for _, span := range spans {
+		if span.Name == "leeway.phase" {
+			for _, attr := range span.Attributes {
+				if string(attr.Key) == "leeway.phase.name" {
+					phaseName := attr.Value.AsString()
+					foundPhases[phaseName] = true
 
-			// Verify duration is reasonable (should be around 100-200ms for each phase)
-			duration := attr.Value.AsInt64()
-			if duration < 50 || duration > 300 {
-				t.Errorf("Phase '%s' duration %dms seems unreasonable", phase, duration)
+					// Verify span has reasonable duration
+					duration := span.EndTime.Sub(span.StartTime)
+					if duration < 5*time.Millisecond || duration > 100*time.Millisecond {
+						t.Errorf("Phase '%s' duration %v seems unreasonable", phaseName, duration)
+					}
+				}
 			}
 		}
 	}
 
 	for _, phase := range expectedPhases {
 		if !foundPhases[phase] {
-			t.Errorf("Expected phase duration attribute for '%s' not found", phase)
+			t.Errorf("Expected phase span for '%s' not found", phase)
 		}
 	}
 }

--- a/pkg/leeway/reporter_test.go
+++ b/pkg/leeway/reporter_test.go
@@ -7,10 +7,14 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gookit/color"
 )
 
 func TestConsoleReporter(t *testing.T) {
 	t.Parallel()
+
+	// Disable colors for consistent test output across environments.
+	color.Enable = false
 
 	type Expectation struct {
 		Output string


### PR DESCRIPTION
## Description

Add individual spans for each build phase (prep, pull, lint, test, build, package) as children of package spans. This enables detailed timeline visualization in tracing backends to identify which phases are slow.

Introduces `PhaseAwareReporter` as an optional interface to avoid breaking existing reporters.

## Related Issue(s)

Continues work from #298 (CLC-2107)

## How to test

1. Run a build with OTel tracing enabled:
   ```bash
   docker run -d --name jaeger -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
   export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4318
   export OTEL_EXPORTER_OTLP_INSECURE=true
   leeway build :some-package
   ```

https://ui.honeycomb.io/gitpod/environments/ci/datasets/leeway/result/ae66p1rchvr/trace/3LPtEYh6jZK?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&fields%5B%5D=c_leeway.package.name&fields%5B%5D=c_leeway.phase.name&span=220f13ac101e37de&zoom=220f13ac101e37de

<img width="838" height="270" alt="image" src="https://github.com/user-attachments/assets/199950ea-03ea-46d9-ad05-87faef3ef6de" />

