### PR TITLE
feat: auto-convert Go library deps to weak dependencies

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -241,6 +241,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("report-github", os.Getenv("GITHUB_OUTPUT") != "", "Report package build success/failure to GitHub Actions using the GITHUB_OUTPUT environment variable")
 	cmd.Flags().Bool("fixed-build-dir", true, "Use a fixed build directory for each package, instead of based on the package version, to better utilize caches based on absolute paths (defaults to true)")
 	cmd.Flags().Bool("docker-export-to-cache", false, "Export Docker images to cache instead of pushing directly (enables SLSA L3 compliance)")
+	cmd.Flags().Bool("go-library-weak-deps", false, "Treat Go library dependencies as weak dependencies (copy source instead of built artifacts)")
 }
 
 func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
@@ -412,6 +413,11 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		dockerExportSet = true
 	}
 
+	goLibraryWeakDeps, err := cmd.Flags().GetBool("go-library-weak-deps")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return []leeway.BuildOption{
 		leeway.WithLocalCache(localCache),
 		leeway.WithRemoteCache(remoteCache),
@@ -430,6 +436,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		leeway.WithInFlightChecksums(inFlightChecksums),
 		leeway.WithDockerExportToCache(dockerExportToCache, dockerExportSet),
 		leeway.WithDockerExportEnv(dockerExportEnvValue, dockerExportEnvSet),
+		leeway.WithGoLibraryWeakDeps(goLibraryWeakDeps),
 	}, localCache
 }
 

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -258,6 +258,61 @@ func (c *buildContext) ReleaseBuildLock(p *Package) {
 	c.pkgLockCond.L.Unlock()
 }
 
+// GetEffectiveDependencies returns the dependencies to use for a package.
+// When GoLibraryWeakDeps is disabled, weak deps are treated as hard deps.
+func (c *buildContext) GetEffectiveDependencies(p *Package) []*Package {
+	if c.GoLibraryWeakDeps {
+		return p.GetDependencies()
+	}
+	// Combine hard and weak deps when feature is disabled
+	deps := p.GetDependencies()
+	weakDeps := p.GetWeakDependencies()
+	if len(weakDeps) == 0 {
+		return deps
+	}
+	result := make([]*Package, 0, len(deps)+len(weakDeps))
+	result = append(result, deps...)
+	result = append(result, weakDeps...)
+	return result
+}
+
+// GetEffectiveTransitiveDependencies returns all transitive dependencies.
+// When GoLibraryWeakDeps is disabled, weak deps are included as hard deps.
+func (c *buildContext) GetEffectiveTransitiveDependencies(p *Package) []*Package {
+	if c.GoLibraryWeakDeps {
+		return p.GetTransitiveDependencies()
+	}
+	// When feature is disabled, include weak deps in transitive deps
+	seen := make(map[string]bool)
+	var result []*Package
+
+	var collect func(pkg *Package)
+	collect = func(pkg *Package) {
+		if seen[pkg.FullName()] {
+			return
+		}
+		seen[pkg.FullName()] = true
+		result = append(result, pkg)
+
+		for _, dep := range pkg.GetDependencies() {
+			collect(dep)
+		}
+		for _, dep := range pkg.GetWeakDependencies() {
+			collect(dep)
+		}
+	}
+
+	// Collect from all direct deps (hard + weak)
+	for _, dep := range p.GetDependencies() {
+		collect(dep)
+	}
+	for _, dep := range p.GetWeakDependencies() {
+		collect(dep)
+	}
+
+	return result
+}
+
 // InitWeakDepTracking initializes tracking for weak dependency build results.
 // Must be called before starting weak dep builds.
 func (c *buildContext) InitWeakDepTracking(weakDeps []*Package) {
@@ -586,6 +641,11 @@ type buildOptions struct {
 	DockerExportEnvValue bool // Value from explicit user env var
 	DockerExportEnvSet   bool // Whether user explicitly set env var (before workspace)
 
+	// GoLibraryWeakDeps enables treating Go library dependencies as weak dependencies.
+	// When enabled, Go library deps copy source code instead of built artifacts,
+	// allowing parallel builds while still running tests.
+	GoLibraryWeakDeps bool
+
 	context *buildContext
 }
 
@@ -734,6 +794,16 @@ func WithDockerExportEnv(value, isSet bool) BuildOption {
 	}
 }
 
+// WithGoLibraryWeakDeps enables treating Go library dependencies as weak dependencies.
+// When enabled, Go library deps copy source code instead of built artifacts,
+// allowing parallel builds while still running tests.
+func WithGoLibraryWeakDeps(enabled bool) BuildOption {
+	return func(opts *buildOptions) error {
+		opts.GoLibraryWeakDeps = enabled
+		return nil
+	}
+}
+
 func withBuildContext(ctx *buildContext) BuildOption {
 	return func(opts *buildOptions) error {
 		opts.context = ctx
@@ -778,21 +848,27 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 		return err
 	}
 
-	requirements := pkg.GetTransitiveDependencies()
+	// Get all packages to build - uses effective deps which includes weak deps
+	// as hard deps when the feature is disabled
+	requirements := ctx.GetEffectiveTransitiveDependencies(pkg)
 	allpkg := append(requirements, pkg)
 
-	weakDeps := collectWeakDependencies(pkg)
-	for _, wd := range weakDeps {
-		// Only add if not already in allpkg (avoid duplicates)
-		found := false
-		for _, p := range allpkg {
-			if p.FullName() == wd.FullName() {
-				found = true
-				break
+	// Only collect weak deps separately if the feature is enabled
+	var weakDeps []*Package
+	if ctx.GoLibraryWeakDeps {
+		weakDeps = collectWeakDependencies(pkg)
+		for _, wd := range weakDeps {
+			// Only add if not already in allpkg (avoid duplicates)
+			found := false
+			for _, p := range allpkg {
+				if p.FullName() == wd.FullName() {
+					found = true
+					break
+				}
 			}
-		}
-		if !found {
-			allpkg = append(allpkg, wd)
+			if !found {
+				allpkg = append(allpkg, wd)
+			}
 		}
 	}
 
@@ -1191,7 +1267,8 @@ func writeBuildPlan(out io.Writer, pkg *Package, status map[*Package]PackageBuil
 }
 
 func (p *Package) buildDependencies(buildctx *buildContext) error {
-	deps := p.GetDependencies()
+	// Use effective dependencies - includes weak deps as hard deps when feature is disabled
+	deps := buildctx.GetEffectiveDependencies(p)
 	if deps == nil {
 		return xerrors.Errorf("package \"%s\" is not linked", p.FullName())
 	}
@@ -2285,15 +2362,21 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 	// We don't check if ephemeral packages in the transitive dependency tree have been built,
 	// as they may be too far down the tree to trigger a build (e.g. their parent may be built already).
 	// Hence, we need to ensure all direct dependencies on ephemeral packages have been built.
-	for _, deppkg := range p.GetDependencies() {
+	for _, deppkg := range buildctx.GetEffectiveDependencies(p) {
 		_, ok := buildctx.LocalCache.Location(deppkg)
 		if deppkg.Ephemeral && !ok {
 			return nil, PkgNotBuiltErr{deppkg}
 		}
 	}
 
-	transdep := p.GetTransitiveDependencies()
-	weakdeps := p.GetTransitiveWeakDependencies()
+	// Get transitive dependencies - when feature is disabled, this includes weak deps as hard deps
+	transdep := buildctx.GetEffectiveTransitiveDependencies(p)
+
+	// Only use weak deps (source copy) if the feature is enabled via CLI flag
+	var weakdeps []*Package
+	if buildctx.GoLibraryWeakDeps {
+		weakdeps = p.GetTransitiveWeakDependencies()
+	}
 	needsDepsDir := len(transdep) > 0 || len(weakdeps) > 0
 
 	if needsDepsDir {

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -82,6 +82,35 @@ type buildContext struct {
 	InFlightChecksums      bool              // Feature enabled flag
 	artifactChecksums      map[string]string // path -> sha256 hex
 	artifactChecksumsMutex sync.RWMutex      // Thread safety for parallel builds
+
+	// Weak dependency result tracking
+	// Allows packages to wait for their weak deps to complete before marking success
+	weakDepResults   map[string]*weakDepResult
+	weakDepResultsMu sync.RWMutex
+}
+
+// weakDepResult tracks the build result of a weak dependency.
+// Uses a closed channel as broadcast mechanism - multiple waiters can wait on the same result.
+type weakDepResult struct {
+	done chan struct{} // Closed when build completes - acts as broadcast
+	err  error         // Build error (nil if success), set before closing done
+}
+
+func newWeakDepResult() *weakDepResult {
+	return &weakDepResult{done: make(chan struct{})}
+}
+
+// Wait blocks until the weak dep build completes and returns the result.
+// Multiple goroutines can call Wait on the same result.
+func (r *weakDepResult) Wait() error {
+	<-r.done
+	return r.err
+}
+
+// Signal marks the weak dep build as complete and broadcasts to all waiters.
+func (r *weakDepResult) Signal(err error) {
+	r.err = err
+	close(r.done)
 }
 
 const (
@@ -227,6 +256,71 @@ func (c *buildContext) ReleaseBuildLock(p *Package) {
 	delete(c.pkgLocks, key)
 	c.pkgLockCond.Broadcast()
 	c.pkgLockCond.L.Unlock()
+}
+
+// InitWeakDepTracking initializes tracking for weak dependency build results.
+// Must be called before starting weak dep builds.
+func (c *buildContext) InitWeakDepTracking(weakDeps []*Package) {
+	c.weakDepResultsMu.Lock()
+	defer c.weakDepResultsMu.Unlock()
+
+	c.weakDepResults = make(map[string]*weakDepResult)
+	for _, wd := range weakDeps {
+		c.weakDepResults[wd.FullName()] = newWeakDepResult()
+	}
+}
+
+// SignalWeakDepComplete marks a weak dependency build as complete.
+// Broadcasts the result to all packages waiting on this weak dep.
+func (c *buildContext) SignalWeakDepComplete(pkg *Package, err error) {
+	c.weakDepResultsMu.RLock()
+	result, ok := c.weakDepResults[pkg.FullName()]
+	c.weakDepResultsMu.RUnlock()
+
+	if ok {
+		result.Signal(err)
+	}
+}
+
+// WaitForWeakDeps waits for all weak dependencies of a package to complete.
+// This includes weak deps of the package itself AND weak deps of its transitive hard dependencies.
+// Returns an error if any weak dep failed.
+func (c *buildContext) WaitForWeakDeps(pkg *Package) error {
+	// Collect all weak deps: direct weak deps + weak deps of hard deps
+	weakDepsToWait := make(map[string]struct{})
+
+	// Add direct weak deps
+	for _, wd := range pkg.GetTransitiveWeakDependencies() {
+		weakDepsToWait[wd.FullName()] = struct{}{}
+	}
+
+	// Add weak deps of hard dependencies (transitive)
+	for _, dep := range pkg.GetTransitiveDependencies() {
+		for _, wd := range dep.GetTransitiveWeakDependencies() {
+			weakDepsToWait[wd.FullName()] = struct{}{}
+		}
+	}
+
+	if len(weakDepsToWait) == 0 {
+		return nil
+	}
+
+	for wdName := range weakDepsToWait {
+		c.weakDepResultsMu.RLock()
+		result, ok := c.weakDepResults[wdName]
+		c.weakDepResultsMu.RUnlock()
+
+		if !ok {
+			// Not tracked - might be cached or not a weak dep of this build
+			continue
+		}
+
+		if err := result.Wait(); err != nil {
+			return xerrors.Errorf("weak dependency %s failed: %w", wdName, err)
+		}
+	}
+
+	return nil
 }
 
 // LimitConcurrentBuilds blocks until there is a free slot to acutally build.
@@ -887,12 +981,19 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 		return nil
 	}
 
+	// Initialize weak dependency result tracking
+	// This allows packages to wait for their weak deps before marking success
+	ctx.InitWeakDepTracking(weakDeps)
+
 	var buildGroup errgroup.Group
 
+	// Start weak dep builds with result signaling
 	for _, wd := range weakDeps {
 		weakDep := wd
 		buildGroup.Go(func() error {
-			return weakDep.build(ctx)
+			err := weakDep.build(ctx)
+			ctx.SignalWeakDepComplete(weakDep, err)
+			return err
 		})
 	}
 
@@ -1131,35 +1232,6 @@ func (p *Package) buildDependencies(buildctx *buildContext) error {
 	return nil
 }
 
-func (p *Package) buildWeakDeps(buildctx *buildContext) {
-	weakDeps := p.GetTransitiveWeakDependencies()
-	if len(weakDeps) == 0 {
-		return
-	}
-
-	log.WithFields(log.Fields{
-		"package":  p.FullName(),
-		"weakDeps": len(weakDeps),
-	}).Debug("building weak deps in background")
-
-	var wg errgroup.Group
-	for _, dep := range weakDeps {
-		d := dep
-		wg.Go(func() error {
-			return d.build(buildctx)
-		})
-	}
-
-	// Don't block on weak deps - they run in parallel
-	// Errors are logged but don't fail the main build
-	if err := wg.Wait(); err != nil {
-		log.WithFields(log.Fields{
-			"package": p.FullName(),
-			"error":   err,
-		}).Warn("weak dep build failed")
-	}
-}
-
 func (p *Package) build(buildctx *buildContext) (err error) {
 	// Try to obtain lock for building this package
 	doBuild := buildctx.ObtainBuildLock(p)
@@ -1180,10 +1252,6 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 	if err := p.buildDependencies(buildctx); err != nil {
 		return err
 	}
-
-	// Start building weak deps in parallel (they don't block this build)
-	// This ensures weak deps are built (for their tests) even when build() is called directly
-	go p.buildWeakDeps(buildctx)
 
 	// Check again after dependencies - might have been built as a dependency
 	if _, alreadyBuilt := buildctx.LocalCache.Location(p); !p.Ephemeral && alreadyBuilt {
@@ -1229,9 +1297,9 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 		return err
 	}
 
-	// Acquire build resources
+	// Acquire build resources - released after build completes but before waiting for weak deps.
+	// We use a closure to ensure proper release on all exit paths.
 	buildctx.LimitConcurrentBuilds()
-	defer buildctx.ReleaseConcurrentBuild()
 
 	// Build the package based on its type
 	var (
@@ -1240,102 +1308,130 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 		sources   fileset
 	)
 
-	switch p.Type {
-	case YarnPackage:
-		bld, err = p.buildYarn(buildctx, builddir, result)
-	case GoPackage:
-		bld, err = p.buildGo(buildctx, builddir, result)
-	case DockerPackage:
-		bld, err = p.buildDocker(buildctx, builddir, result)
-	case GenericPackage:
-		bld, err = p.buildGeneric(buildctx, builddir, result)
-	default:
-		return xerrors.Errorf("cannot build package type: %s", p.Type)
-	}
+	// Execute the CPU/memory intensive build work, then release the semaphore.
+	// This allows other packages to start building while we wait for weak deps.
+	buildErr := func() error {
+		defer buildctx.ReleaseConcurrentBuild()
 
-	if err != nil {
-		return err
-	}
-
-	// Handle provenance if enabled
-	now := time.Now()
-	if p.C.W.Provenance.Enabled {
-		if sources, err = computeFileset(builddir); err != nil {
-			return err
+		switch p.Type {
+		case YarnPackage:
+			bld, err = p.buildYarn(buildctx, builddir, result)
+		case GoPackage:
+			bld, err = p.buildGo(buildctx, builddir, result)
+		case DockerPackage:
+			bld, err = p.buildDocker(buildctx, builddir, result)
+		case GenericPackage:
+			bld, err = p.buildGeneric(buildctx, builddir, result)
+		default:
+			return xerrors.Errorf("cannot build package type: %s", p.Type)
 		}
-	}
 
-	// Execute build phases
-	for _, phase := range []PackageBuildPhase{
-		PackageBuildPhasePrep,
-		PackageBuildPhasePull,
-		PackageBuildPhaseLint,
-		PackageBuildPhaseTest,
-		PackageBuildPhaseBuild,
-	} {
-		if err := executeBuildPhase(buildctx, p, builddir, bld, phase, pkgRep); err != nil {
-			return err
-		}
-	}
-
-	// Execute post-processing hook if available - this should run regardless of provenance settings
-	if bld.PostProcess != nil {
-		log.WithField("package", p.FullName()).Debug("running post-processing hook")
-		if err := bld.PostProcess(buildctx, p, builddir); err != nil {
-			return xerrors.Errorf("post-processing failed: %w", err)
-		}
-	}
-
-	// Handle test coverage if available (before packaging - needs _deps)
-	if bld.TestCoverage != nil {
-		coverage, funcsWithoutTest, funcsWithTest, err := bld.TestCoverage()
 		if err != nil {
 			return err
 		}
-		pkgRep.TestCoverageAvailable = true
-		pkgRep.TestCoveragePercentage = coverage
-		pkgRep.FunctionsWithoutTest = funcsWithoutTest
-		pkgRep.FunctionsWithTest = funcsWithTest
+
+		// Handle provenance if enabled
+		now := time.Now()
+		if p.C.W.Provenance.Enabled {
+			if sources, err = computeFileset(builddir); err != nil {
+				return err
+			}
+		}
+
+		// Execute build phases
+		for _, phase := range []PackageBuildPhase{
+			PackageBuildPhasePrep,
+			PackageBuildPhasePull,
+			PackageBuildPhaseLint,
+			PackageBuildPhaseTest,
+			PackageBuildPhaseBuild,
+		} {
+			if err := executeBuildPhase(buildctx, p, builddir, bld, phase, pkgRep); err != nil {
+				return err
+			}
+		}
+
+		// Execute post-processing hook if available - this should run regardless of provenance settings
+		if bld.PostProcess != nil {
+			log.WithField("package", p.FullName()).Debug("running post-processing hook")
+			if err := bld.PostProcess(buildctx, p, builddir); err != nil {
+				return xerrors.Errorf("post-processing failed: %w", err)
+			}
+		}
+
+		// Handle test coverage if available (before packaging - needs _deps)
+		if bld.TestCoverage != nil {
+			coverage, funcsWithoutTest, funcsWithTest, err := bld.TestCoverage()
+			if err != nil {
+				return err
+			}
+			pkgRep.TestCoverageAvailable = true
+			pkgRep.TestCoveragePercentage = coverage
+			pkgRep.FunctionsWithoutTest = funcsWithoutTest
+			pkgRep.FunctionsWithTest = funcsWithTest
+		}
+
+		// Package the build results
+		if len(bld.Commands[PackageBuildPhasePackage]) > 0 {
+			if err := executeCommandsForPackage(buildctx, p, builddir, bld.Commands[PackageBuildPhasePackage]); err != nil {
+				return err
+			}
+		}
+
+		// Record checksum immediately after cache artifact creation
+		if cacheArtifactPath, exists := buildctx.LocalCache.Location(p); exists {
+			if err := buildctx.recordArtifactChecksum(cacheArtifactPath); err != nil {
+				log.WithError(err).WithField("package", p.FullName()).Warn("Failed to record cache artifact checksum")
+				// Don't fail build - this is defensive, not critical path
+			}
+		}
+
+		// Handle provenance subjects (after packaging - artifact now exists)
+		if p.C.W.Provenance.Enabled {
+			if err := handleProvenance(p, buildctx, builddir, bld, sources, now); err != nil {
+				return err
+			}
+		}
+
+		// Generate SBOM if enabled (after packaging - written alongside artifact)
+		// SBOM files are stored outside the tar.gz to maintain artifact determinism.
+		if p.C.W.SBOM.Enabled {
+			if par, ok := buildctx.Reporter.(PhaseAwareReporter); ok {
+				par.PackageBuildPhaseStarted(p, PackageBuildPhaseSBOM)
+			}
+			pkgRep.phaseEnter[PackageBuildPhaseSBOM] = time.Now()
+			pkgRep.Phases = append(pkgRep.Phases, PackageBuildPhaseSBOM)
+			sbomErr := writeSBOMToCache(buildctx, p, builddir)
+			pkgRep.phaseDone[PackageBuildPhaseSBOM] = time.Now()
+			if par, ok := buildctx.Reporter.(PhaseAwareReporter); ok {
+				par.PackageBuildPhaseFinished(p, PackageBuildPhaseSBOM, sbomErr)
+			}
+			if sbomErr != nil {
+				return sbomErr
+			}
+		}
+
+		return nil
+	}()
+
+	if buildErr != nil {
+		return buildErr
 	}
 
-	// Package the build results
-	if len(bld.Commands[PackageBuildPhasePackage]) > 0 {
-		if err := executeCommandsForPackage(buildctx, p, builddir, bld.Commands[PackageBuildPhasePackage]); err != nil {
-			return err
+	// Semaphore is now released - wait for weak deps without holding build resources.
+	// All packages wait for their weak deps, including packages that are themselves weak deps.
+	// This ensures transitive weak dep failures propagate (App -> Lib1 -> Lib2: if Lib2 fails, Lib1 fails too).
+	if err := buildctx.WaitForWeakDeps(p); err != nil {
+		// Weak dep failed - remove the artifact from cache to prevent
+		// subsequent runs from using a potentially invalid build.
+		if cachePath, exists := buildctx.LocalCache.Location(p); exists {
+			if removeErr := os.Remove(cachePath); removeErr != nil {
+				log.WithError(removeErr).WithField("package", p.FullName()).Warn("Failed to remove artifact from cache after weak dep failure")
+			} else {
+				log.WithField("package", p.FullName()).Debug("Removed artifact from cache due to weak dep failure")
+			}
 		}
-	}
-
-	// Record checksum immediately after cache artifact creation
-	if cacheArtifactPath, exists := buildctx.LocalCache.Location(p); exists {
-		if err := buildctx.recordArtifactChecksum(cacheArtifactPath); err != nil {
-			log.WithError(err).WithField("package", p.FullName()).Warn("Failed to record cache artifact checksum")
-			// Don't fail build - this is defensive, not critical path
-		}
-	}
-
-	// Handle provenance subjects (after packaging - artifact now exists)
-	if p.C.W.Provenance.Enabled {
-		if err := handleProvenance(p, buildctx, builddir, bld, sources, now); err != nil {
-			return err
-		}
-	}
-
-	// Generate SBOM if enabled (after packaging - written alongside artifact)
-	// SBOM files are stored outside the tar.gz to maintain artifact determinism.
-	if p.C.W.SBOM.Enabled {
-		if par, ok := buildctx.Reporter.(PhaseAwareReporter); ok {
-			par.PackageBuildPhaseStarted(p, PackageBuildPhaseSBOM)
-		}
-		pkgRep.phaseEnter[PackageBuildPhaseSBOM] = time.Now()
-		pkgRep.Phases = append(pkgRep.Phases, PackageBuildPhaseSBOM)
-		sbomErr := writeSBOMToCache(buildctx, p, builddir)
-		pkgRep.phaseDone[PackageBuildPhaseSBOM] = time.Now()
-		if par, ok := buildctx.Reporter.(PhaseAwareReporter); ok {
-			par.PackageBuildPhaseFinished(p, PackageBuildPhaseSBOM, sbomErr)
-		}
-		if sbomErr != nil {
-			return sbomErr
-		}
+		return err
 	}
 
 	// Register newly built package
@@ -1425,6 +1521,44 @@ func copySources(p *Package, builddir string) error {
 	}
 
 	return nil
+}
+
+// copyWeakDepSourceCommands generates shell commands to copy a weak dependency's
+// source files (respecting its src rules) to the target directory.
+// The tgt path is relative to the build directory where commands will be executed.
+func copyWeakDepSourceCommands(dep *Package, tgt string) [][]string {
+	if len(dep.Sources) == 0 {
+		return nil
+	}
+
+	var commands [][]string
+	commands = append(commands, []string{"mkdir", "-p", tgt})
+
+	// Group files by whether they're under the package origin
+	var parentedFiles []string
+	prefix := dep.C.Origin + "/"
+
+	for _, src := range dep.Sources {
+		if strings.HasPrefix(src, prefix) {
+			parentedFiles = append(parentedFiles, strings.TrimPrefix(src, prefix))
+		}
+		// Files not under the package origin are skipped - they shouldn't exist
+		// for properly configured packages
+	}
+
+	// Copy files preserving directory structure
+	// We use a subshell that: 1) saves current dir, 2) cd to source, 3) cp --parents to absolute target
+	if len(parentedFiles) > 0 {
+		// Build the cp command with all files
+		// Using $PWD to get absolute path of tgt since we'll cd to dep.C.Origin
+		cmd := fmt.Sprintf("dest=\"$PWD/%s\" && cd %s && cp --parents -r %s \"$dest\"",
+			tgt,
+			dep.C.Origin,
+			strings.Join(parentedFiles, " "))
+		commands = append(commands, []string{"sh", "-c", cmd})
+	}
+
+	return commands
 }
 
 func executeBuildPhase(buildctx *buildContext, p *Package, builddir string, bld *packageBuild, phase PackageBuildPhase, pkgRep *PackageBuildReport) error {
@@ -2210,12 +2344,10 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (res *packa
 		}
 
 		tgt := filepath.Join("_deps", p.BuildLayoutLocation(dep))
-		srcDir := dep.C.Origin
 
-		commands[PackageBuildPhasePrep] = append(commands[PackageBuildPhasePrep], [][]string{
-			{"mkdir", "-p", tgt},
-			{"sh", "-c", fmt.Sprintf("cp -r %s/* %s/", srcDir, tgt)},
-		}...)
+		// Copy only the sources defined in the weak dependency's src rules
+		commands[PackageBuildPhasePrep] = append(commands[PackageBuildPhasePrep],
+			copyWeakDepSourceCommands(dep, tgt)...)
 
 		if isGoWorkspace {
 			commands[PackageBuildPhasePrep] = append(commands[PackageBuildPhasePrep], []string{"go", "work", "use", tgt})

--- a/pkg/leeway/build_internal_test.go
+++ b/pkg/leeway/build_internal_test.go
@@ -85,36 +85,6 @@ func TestCollectWeakDependencies(t *testing.T) {
 		}
 	})
 
-	t.Run("collects hard deps of weak deps", func(t *testing.T) {
-		// lib-a has a hard dep on generic-pkg
-		genericPkg := newPkg("generic-pkg", GenericPackage, nil)
-		genericPkg.dependencies = []*Package{}
-		genericPkg.weakDependencies = []*Package{}
-
-		libA := newPkg("lib-a", GoPackage, GoLibrary)
-		libA.dependencies = []*Package{genericPkg} // hard dep
-		libA.weakDependencies = []*Package{}
-
-		app := newPkg("app", GoPackage, GoApp)
-		app.dependencies = []*Package{}
-		app.weakDependencies = []*Package{libA}
-
-		result := collectWeakDependencies(app)
-
-		// Should collect lib-a and generic-pkg
-		if len(result) != 2 {
-			t.Errorf("expected 2 deps, got %d: %v", len(result), result)
-		}
-
-		names := make(map[string]bool)
-		for _, p := range result {
-			names[p.Name] = true
-		}
-		if !names["lib-a"] || !names["generic-pkg"] {
-			t.Errorf("expected lib-a and generic-pkg, got %v", names)
-		}
-	})
-
 	t.Run("collects weak deps from hard deps", func(t *testing.T) {
 		// app -> hard-dep -> lib-a (weak)
 		libA := newPkg("lib-a", GoPackage, GoLibrary)
@@ -163,101 +133,7 @@ func TestCollectWeakDependencies(t *testing.T) {
 	})
 }
 
-func TestCollectHardDepsOfWeakDeps(t *testing.T) {
-	newPkg := func(name string, pkgType PackageType, packaging interface{}) *Package {
-		pkg := &Package{
-			C: &Component{
-				W:      &Workspace{Packages: make(map[string]*Package)},
-				Origin: "test",
-				Name:   "test",
-			},
-			PackageInternal: PackageInternal{Name: name, Type: pkgType},
-		}
-		switch pkgType {
-		case GoPackage:
-			if p, ok := packaging.(GoPackaging); ok {
-				pkg.Config = GoPkgConfig{Packaging: p}
-			}
-		case GenericPackage:
-			pkg.Config = GenericPkgConfig{}
-		}
-		return pkg
-	}
 
-	t.Run("collects hard deps of weak deps", func(t *testing.T) {
-		// go-lib depends on generic-pkg (hard dep)
-		genericPkg := newPkg("generic-pkg", GenericPackage, nil)
-		genericPkg.dependencies = []*Package{}
-		genericPkg.weakDependencies = []*Package{}
-
-		goLib := newPkg("go-lib", GoPackage, GoLibrary)
-		goLib.dependencies = []*Package{genericPkg}
-		goLib.weakDependencies = []*Package{}
-
-		weakdeps := []*Package{goLib}
-		transdep := []*Package{} // app has no direct hard deps
-
-		result := collectHardDepsOfWeakDeps(weakdeps, transdep)
-
-		if len(result) != 1 {
-			t.Errorf("expected 1 hard dep of weak dep, got %d", len(result))
-		}
-		if result[0].Name != "generic-pkg" {
-			t.Errorf("expected generic-pkg, got %s", result[0].Name)
-		}
-	})
-
-	t.Run("excludes deps already in transdep", func(t *testing.T) {
-		genericPkg := newPkg("generic-pkg", GenericPackage, nil)
-		genericPkg.dependencies = []*Package{}
-		genericPkg.weakDependencies = []*Package{}
-
-		goLib := newPkg("go-lib", GoPackage, GoLibrary)
-		goLib.dependencies = []*Package{genericPkg}
-		goLib.weakDependencies = []*Package{}
-
-		weakdeps := []*Package{goLib}
-		transdep := []*Package{genericPkg} // already in transdep
-
-		result := collectHardDepsOfWeakDeps(weakdeps, transdep)
-
-		if len(result) != 0 {
-			t.Errorf("expected 0 (already in transdep), got %d", len(result))
-		}
-	})
-
-	t.Run("collects nested hard deps", func(t *testing.T) {
-		// go-lib -> generic-a -> generic-b
-		genericB := newPkg("generic-b", GenericPackage, nil)
-		genericB.dependencies = []*Package{}
-		genericB.weakDependencies = []*Package{}
-
-		genericA := newPkg("generic-a", GenericPackage, nil)
-		genericA.dependencies = []*Package{genericB}
-		genericA.weakDependencies = []*Package{}
-
-		goLib := newPkg("go-lib", GoPackage, GoLibrary)
-		goLib.dependencies = []*Package{genericA}
-		goLib.weakDependencies = []*Package{}
-
-		weakdeps := []*Package{goLib}
-		transdep := []*Package{}
-
-		result := collectHardDepsOfWeakDeps(weakdeps, transdep)
-
-		if len(result) != 2 {
-			t.Errorf("expected 2 hard deps, got %d", len(result))
-		}
-
-		names := make(map[string]bool)
-		for _, p := range result {
-			names[p.Name] = true
-		}
-		if !names["generic-a"] || !names["generic-b"] {
-			t.Errorf("expected generic-a and generic-b, got %v", names)
-		}
-	})
-}
 
 func TestDefaultGoBuildCommand_IncludesTrimpath(t *testing.T) {
 	// The default Go build command should include -trimpath for reproducible builds.

--- a/pkg/leeway/build_internal_test.go
+++ b/pkg/leeway/build_internal_test.go
@@ -14,34 +14,246 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestCollectWeakDependencies(t *testing.T) {
-	// Helper to create test packages
-	newPkg := func(name string, pkgType PackageType, packaging interface{}) *Package {
-		pkg := &Package{
-			C: &Component{
-				W:      &Workspace{Packages: make(map[string]*Package)},
-				Origin: "test",
-				Name:   "test",
-			},
-			PackageInternal: PackageInternal{Name: name, Type: pkgType},
-		}
-		switch pkgType {
-		case GoPackage:
-			if p, ok := packaging.(GoPackaging); ok {
-				pkg.Config = GoPkgConfig{Packaging: p}
-			}
-		case GenericPackage:
-			pkg.Config = GenericPkgConfig{}
-		}
-		return pkg
+// Helper to create test packages for weak dep tests
+func newTestPkg(name string, pkgType PackageType, packaging interface{}) *Package {
+	pkg := &Package{
+		C: &Component{
+			W:      &Workspace{Packages: make(map[string]*Package)},
+			Origin: "test",
+			Name:   "test",
+		},
+		PackageInternal: PackageInternal{Name: name, Type: pkgType},
 	}
+	switch pkgType {
+	case GoPackage:
+		if p, ok := packaging.(GoPackaging); ok {
+			pkg.Config = GoPkgConfig{Packaging: p}
+		}
+	case GenericPackage:
+		pkg.Config = GenericPkgConfig{}
+	}
+	return pkg
+}
 
-	t.Run("collects direct weak deps", func(t *testing.T) {
-		libA := newPkg("lib-a", GoPackage, GoLibrary)
+func TestGetEffectiveDependencies(t *testing.T) {
+	t.Run("with flag enabled returns only hard deps", func(t *testing.T) {
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
 		libA.dependencies = []*Package{}
 		libA.weakDependencies = []*Package{}
 
-		app := newPkg("app", GoPackage, GoApp)
+		libB := newTestPkg("lib-b", GoPackage, GoLibrary)
+		libB.dependencies = []*Package{}
+		libB.weakDependencies = []*Package{}
+
+		app := newTestPkg("app", GoPackage, GoApp)
+		app.dependencies = []*Package{libA}      // hard dep
+		app.weakDependencies = []*Package{libB}  // weak dep
+
+		ctx := &buildContext{
+			buildOptions: buildOptions{GoLibraryWeakDeps: true},
+		}
+
+		result := ctx.GetEffectiveDependencies(app)
+
+		if len(result) != 1 {
+			t.Errorf("expected 1 dep (only hard), got %d", len(result))
+		}
+		if result[0].Name != "lib-a" {
+			t.Errorf("expected lib-a, got %s", result[0].Name)
+		}
+	})
+
+	t.Run("with flag disabled returns hard + weak deps", func(t *testing.T) {
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
+		libA.dependencies = []*Package{}
+		libA.weakDependencies = []*Package{}
+
+		libB := newTestPkg("lib-b", GoPackage, GoLibrary)
+		libB.dependencies = []*Package{}
+		libB.weakDependencies = []*Package{}
+
+		app := newTestPkg("app", GoPackage, GoApp)
+		app.dependencies = []*Package{libA}      // hard dep
+		app.weakDependencies = []*Package{libB}  // weak dep
+
+		ctx := &buildContext{
+			buildOptions: buildOptions{GoLibraryWeakDeps: false},
+		}
+
+		result := ctx.GetEffectiveDependencies(app)
+
+		if len(result) != 2 {
+			t.Errorf("expected 2 deps (hard + weak), got %d", len(result))
+		}
+
+		names := make(map[string]bool)
+		for _, p := range result {
+			names[p.Name] = true
+		}
+		if !names["lib-a"] || !names["lib-b"] {
+			t.Errorf("expected lib-a and lib-b, got %v", names)
+		}
+	})
+
+	t.Run("with flag disabled and no weak deps returns only hard deps", func(t *testing.T) {
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
+		libA.dependencies = []*Package{}
+		libA.weakDependencies = []*Package{}
+
+		app := newTestPkg("app", GoPackage, GoApp)
+		app.dependencies = []*Package{libA}
+		app.weakDependencies = []*Package{}
+
+		ctx := &buildContext{
+			buildOptions: buildOptions{GoLibraryWeakDeps: false},
+		}
+
+		result := ctx.GetEffectiveDependencies(app)
+
+		if len(result) != 1 {
+			t.Errorf("expected 1 dep, got %d", len(result))
+		}
+		if result[0].Name != "lib-a" {
+			t.Errorf("expected lib-a, got %s", result[0].Name)
+		}
+	})
+}
+
+func TestGetEffectiveTransitiveDependencies(t *testing.T) {
+	t.Run("with flag enabled returns only hard transitive deps", func(t *testing.T) {
+		// app -> libA (hard) -> libB (weak)
+		libB := newTestPkg("lib-b", GoPackage, GoLibrary)
+		libB.dependencies = []*Package{}
+		libB.weakDependencies = []*Package{}
+
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
+		libA.dependencies = []*Package{}
+		libA.weakDependencies = []*Package{libB}
+
+		app := newTestPkg("app", GoPackage, GoApp)
+		app.dependencies = []*Package{libA}
+		app.weakDependencies = []*Package{}
+
+		ctx := &buildContext{
+			buildOptions: buildOptions{GoLibraryWeakDeps: true},
+		}
+
+		result := ctx.GetEffectiveTransitiveDependencies(app)
+
+		// Should only include libA (hard dep), not libB (weak dep of libA)
+		if len(result) != 1 {
+			t.Errorf("expected 1 transitive dep, got %d: %v", len(result), result)
+		}
+		if result[0].Name != "lib-a" {
+			t.Errorf("expected lib-a, got %s", result[0].Name)
+		}
+	})
+
+	t.Run("with flag disabled returns hard + weak transitive deps", func(t *testing.T) {
+		// app -> libA (hard) -> libB (weak)
+		libB := newTestPkg("lib-b", GoPackage, GoLibrary)
+		libB.dependencies = []*Package{}
+		libB.weakDependencies = []*Package{}
+
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
+		libA.dependencies = []*Package{}
+		libA.weakDependencies = []*Package{libB}
+
+		app := newTestPkg("app", GoPackage, GoApp)
+		app.dependencies = []*Package{libA}
+		app.weakDependencies = []*Package{}
+
+		ctx := &buildContext{
+			buildOptions: buildOptions{GoLibraryWeakDeps: false},
+		}
+
+		result := ctx.GetEffectiveTransitiveDependencies(app)
+
+		// Should include both libA and libB
+		if len(result) != 2 {
+			t.Errorf("expected 2 transitive deps, got %d: %v", len(result), result)
+		}
+
+		names := make(map[string]bool)
+		for _, p := range result {
+			names[p.Name] = true
+		}
+		if !names["lib-a"] || !names["lib-b"] {
+			t.Errorf("expected lib-a and lib-b, got %v", names)
+		}
+	})
+
+	t.Run("with flag disabled includes direct weak deps", func(t *testing.T) {
+		// app -> libA (weak)
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
+		libA.dependencies = []*Package{}
+		libA.weakDependencies = []*Package{}
+
+		app := newTestPkg("app", GoPackage, GoApp)
+		app.dependencies = []*Package{}
+		app.weakDependencies = []*Package{libA}
+
+		ctx := &buildContext{
+			buildOptions: buildOptions{GoLibraryWeakDeps: false},
+		}
+
+		result := ctx.GetEffectiveTransitiveDependencies(app)
+
+		// Should include libA even though it's a weak dep
+		if len(result) != 1 {
+			t.Errorf("expected 1 transitive dep, got %d: %v", len(result), result)
+		}
+		if result[0].Name != "lib-a" {
+			t.Errorf("expected lib-a, got %s", result[0].Name)
+		}
+	})
+
+	t.Run("with flag disabled handles deep transitive weak deps", func(t *testing.T) {
+		// app -> libA (weak) -> libB (weak) -> libC (weak)
+		libC := newTestPkg("lib-c", GoPackage, GoLibrary)
+		libC.dependencies = []*Package{}
+		libC.weakDependencies = []*Package{}
+
+		libB := newTestPkg("lib-b", GoPackage, GoLibrary)
+		libB.dependencies = []*Package{}
+		libB.weakDependencies = []*Package{libC}
+
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
+		libA.dependencies = []*Package{}
+		libA.weakDependencies = []*Package{libB}
+
+		app := newTestPkg("app", GoPackage, GoApp)
+		app.dependencies = []*Package{}
+		app.weakDependencies = []*Package{libA}
+
+		ctx := &buildContext{
+			buildOptions: buildOptions{GoLibraryWeakDeps: false},
+		}
+
+		result := ctx.GetEffectiveTransitiveDependencies(app)
+
+		// Should include all: libA, libB, libC
+		if len(result) != 3 {
+			t.Errorf("expected 3 transitive deps, got %d: %v", len(result), result)
+		}
+
+		names := make(map[string]bool)
+		for _, p := range result {
+			names[p.Name] = true
+		}
+		if !names["lib-a"] || !names["lib-b"] || !names["lib-c"] {
+			t.Errorf("expected lib-a, lib-b, and lib-c, got %v", names)
+		}
+	})
+}
+
+func TestCollectWeakDependencies(t *testing.T) {
+	t.Run("collects direct weak deps", func(t *testing.T) {
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
+		libA.dependencies = []*Package{}
+		libA.weakDependencies = []*Package{}
+
+		app := newTestPkg("app", GoPackage, GoApp)
 		app.dependencies = []*Package{}
 		app.weakDependencies = []*Package{libA}
 
@@ -57,15 +269,15 @@ func TestCollectWeakDependencies(t *testing.T) {
 
 	t.Run("collects nested weak deps (weak dep of weak dep)", func(t *testing.T) {
 		// lib-b depends on lib-a (both are Go libraries)
-		libA := newPkg("lib-a", GoPackage, GoLibrary)
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
 		libA.dependencies = []*Package{}
 		libA.weakDependencies = []*Package{}
 
-		libB := newPkg("lib-b", GoPackage, GoLibrary)
+		libB := newTestPkg("lib-b", GoPackage, GoLibrary)
 		libB.dependencies = []*Package{}
 		libB.weakDependencies = []*Package{libA} // lib-a is weak dep of lib-b
 
-		app := newPkg("app", GoPackage, GoApp)
+		app := newTestPkg("app", GoPackage, GoApp)
 		app.dependencies = []*Package{}
 		app.weakDependencies = []*Package{libB}
 
@@ -87,15 +299,15 @@ func TestCollectWeakDependencies(t *testing.T) {
 
 	t.Run("collects weak deps from hard deps", func(t *testing.T) {
 		// app -> hard-dep -> lib-a (weak)
-		libA := newPkg("lib-a", GoPackage, GoLibrary)
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
 		libA.dependencies = []*Package{}
 		libA.weakDependencies = []*Package{}
 
-		hardDep := newPkg("hard-dep", GoPackage, GoApp)
+		hardDep := newTestPkg("hard-dep", GoPackage, GoApp)
 		hardDep.dependencies = []*Package{}
 		hardDep.weakDependencies = []*Package{libA}
 
-		app := newPkg("app", GoPackage, GoApp)
+		app := newTestPkg("app", GoPackage, GoApp)
 		app.dependencies = []*Package{hardDep}
 		app.weakDependencies = []*Package{}
 
@@ -112,15 +324,15 @@ func TestCollectWeakDependencies(t *testing.T) {
 
 	t.Run("no duplicates", func(t *testing.T) {
 		// Both app and hard-dep depend on lib-a
-		libA := newPkg("lib-a", GoPackage, GoLibrary)
+		libA := newTestPkg("lib-a", GoPackage, GoLibrary)
 		libA.dependencies = []*Package{}
 		libA.weakDependencies = []*Package{}
 
-		hardDep := newPkg("hard-dep", GoPackage, GoApp)
+		hardDep := newTestPkg("hard-dep", GoPackage, GoApp)
 		hardDep.dependencies = []*Package{}
 		hardDep.weakDependencies = []*Package{libA}
 
-		app := newPkg("app", GoPackage, GoApp)
+		app := newTestPkg("app", GoPackage, GoApp)
 		app.dependencies = []*Package{hardDep}
 		app.weakDependencies = []*Package{libA} // also directly depends on lib-a
 


### PR DESCRIPTION
## Summary

Go packages with `packaging: library` are now automatically treated as "weak dependencies" when referenced, improving build parallelism for Go monorepos.

## Motivation

In Go monorepos, libraries are typically used for their source code via `go.mod replace` directives, not for their built artifacts. Previously, leeway would:
1. Build the library first (blocking)
2. Extract the built artifact
3. Then build the dependent package

This was inefficient because the dependent package only needs the library's **source files**, not its built artifact.

## Changes

### Weak Dependencies for Go Libraries

When a Go package with `packaging: library` is listed as a dependency, it's automatically converted to a "weak dependency":

| Aspect | Regular Dependency | Go Library (Weak) |
|--------|-------------------|-------------------|
| Affects package version | ✅ | ✅ |
| Must be built first | ✅ | ❌ |
| What's copied to `_deps/` | Built artifact | Source files |
| `go.mod replace` added | ✅ | ✅ |
| Build runs | Sequentially | In parallel |

### Important Constraint

A Go library can only be a weak dependency if **all its transitive dependencies are also Go libraries**. If a Go library depends on non-Go-library packages (e.g., generic packages), it's treated as a regular hard dependency.

```yaml
# CAN be weak dep - only depends on other Go libraries
go-lib-a:
  type: go
  config:
    packaging: library
  deps:
    - other-go-lib:lib

# MUST be hard dep - depends on a generic package  
go-lib-b:
  type: go
  config:
    packaging: library
  deps:
    - some-generic:pkg
```

### Build Flow

```
Before:
1. Build lib-a (blocking)
2. Build lib-b (blocking) 
3. Build app

After (when libs have only Go library deps):
1. Start in parallel:
   ├── Build app (copies lib-a, lib-b sources to _deps/)
   ├── Build lib-a (runs tests)
   └── Build lib-b (runs tests)
```

### Weak Dependency Failure Propagation

If a weak dependency fails (e.g., tests fail), all packages that depend on it will also fail **before** running their build commands. This prevents publishing packages (e.g., Docker images) when their weak dependencies have failed.

```
Example:
  docker:img -> go-app:app -> go-lib:lib (weak dep)
  
If go-lib tests fail:
1. go-lib:lib build fails
2. go-app:app waits for go-lib, sees failure, fails before building
3. docker:img waits for go-lib (via go-app), sees failure, fails before docker push
```

Implementation uses a broadcast channel pattern - multiple packages can wait on the same weak dep result.

### Cache Behavior

- Source files are always copied from the workspace (not from cache)
- Version manifest includes all transitive weak deps
- Any change to a library invalidates the dependent package's cache

## Example

```yaml
# my-lib/BUILD.yaml
packages:
- name: lib
  type: go
  config:
    packaging: library  # Automatically becomes weak dep when referenced

# my-app/BUILD.yaml  
packages:
- name: app
  type: go
  deps:
    - my-lib:lib  # Sources copied, builds in parallel
  config:
    packaging: app
```

## Testing

- Added unit tests for `canBeWeakDep()` and `checkAllDepsAreGoLibraries()`
- Added unit tests for `GetTransitiveWeakDependencies()`
- Added unit tests for `collectWeakDependencies()`
- Added tests for auto-conversion behavior
- Added tests for version manifest inclusion
- All existing tests pass
- All integration tests pass