### PR TITLE
Add root trace span for build command and fix S3 cache timeout

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -23,8 +23,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-
-
 // buildCmd represents the build command
 var buildCmd = &cobra.Command{
 	Use:   "build [targetPackage]",

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -242,7 +242,7 @@ func TestGetBuildOptsWithInFlightChecksums(t *testing.T) {
 			}
 
 			// Test getBuildOpts function
-			opts, localCache, _ := getBuildOpts(cmd)
+			opts, localCache := getBuildOpts(cmd)
 
 			// We can't directly test the WithInFlightChecksums option since it's internal,
 			// but we can verify the function doesn't error and returns options

--- a/cmd/provenance-assert.go
+++ b/cmd/provenance-assert.go
@@ -125,7 +125,7 @@ func getProvenanceTarget(cmd *cobra.Command, args []string) (bundleFN, pkgFN str
 			log.Fatal("provenance export requires a package")
 		}
 
-		_, cache, _ := getBuildOpts(cmd)
+		_, cache := getBuildOpts(cmd)
 
 		var ok bool
 		pkgFN, ok = cache.Location(pkg)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,7 +27,7 @@ Should any of the scripts fail Leeway will exit with an exit code of 1 once all 
 				if script == nil {
 					return errors.New("run needs a script")
 				}
-				opts, _, _ := getBuildOpts(cmd)
+				opts, _ := getBuildOpts(cmd)
 				return script.Run(opts...)
 			})
 		}

--- a/cmd/sbom-export.go
+++ b/cmd/sbom-export.go
@@ -32,7 +32,7 @@ If no package is specified, the workspace's default target is used.`,
 		}
 
 		// Get build options and cache
-		_, localCache, _ := getBuildOpts(cmd)
+		_, localCache := getBuildOpts(cmd)
 
 		// Get output format and file
 		format, _ := cmd.Flags().GetString("format")

--- a/cmd/sbom-scan.go
+++ b/cmd/sbom-scan.go
@@ -30,7 +30,7 @@ If no package is specified, the workspace's default target is used.`,
 		}
 
 		// Get cache
-		_, localCache, _ := getBuildOpts(cmd)
+		_, localCache := getBuildOpts(cmd)
 
 		// Get output directory
 		outputDir, _ := cmd.Flags().GetString("output-dir")

--- a/pkg/leeway/cache/remote/s3_download_test.go
+++ b/pkg/leeway/cache/remote/s3_download_test.go
@@ -77,15 +77,7 @@ func (m *mockS3Storage) UploadObject(ctx context.Context, key string, src string
 	return nil
 }
 
-func (m *mockS3Storage) ListObjects(ctx context.Context, prefix string) ([]string, error) {
-	var result []string
-	for key := range m.objects {
-		if len(prefix) == 0 || key[:len(prefix)] == prefix {
-			result = append(result, key)
-		}
-	}
-	return result, nil
-}
+
 
 func TestS3CacheDownload(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/pkg/leeway/cache/remote/s3_download_test.go
+++ b/pkg/leeway/cache/remote/s3_download_test.go
@@ -77,8 +77,6 @@ func (m *mockS3Storage) UploadObject(ctx context.Context, key string, src string
 	return nil
 }
 
-
-
 func TestS3CacheDownload(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/leeway/cache/remote/s3_performance_test.go
+++ b/pkg/leeway/cache/remote/s3_performance_test.go
@@ -115,8 +115,6 @@ func (m *realisticMockS3Storage) UploadObject(ctx context.Context, key string, s
 	return nil
 }
 
-
-
 // realisticMockVerifier implements realistic SLSA verification performance
 type realisticMockVerifier struct{}
 

--- a/pkg/leeway/cache/remote/s3_performance_test.go
+++ b/pkg/leeway/cache/remote/s3_performance_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -116,22 +115,7 @@ func (m *realisticMockS3Storage) UploadObject(ctx context.Context, key string, s
 	return nil
 }
 
-func (m *realisticMockS3Storage) ListObjects(ctx context.Context, prefix string) ([]string, error) {
-	// Simulate network latency for list operation
-	latency := m.latency
-	if latency == 0 {
-		latency = s3Latency // Default to realistic latency
-	}
-	time.Sleep(latency / 2)
 
-	var keys []string
-	for key := range m.objects {
-		if strings.HasPrefix(key, prefix) {
-			keys = append(keys, key)
-		}
-	}
-	return keys, nil
-}
 
 // realisticMockVerifier implements realistic SLSA verification performance
 type realisticMockVerifier struct{}
@@ -417,9 +401,8 @@ func TestS3Cache_ParallelVerificationScaling(t *testing.T) {
 	}
 }
 
-// TestS3Cache_ExistingPackagesBatchOptimization tests the ListObjects optimization
-func TestS3Cache_ExistingPackagesBatchOptimization(t *testing.T) {
-	// Use reduced latency for fast tests
+// TestS3Cache_ExistingPackagesParallel tests parallel HeadObject checks
+func TestS3Cache_ExistingPackagesParallel(t *testing.T) {
 	packageCounts := []int{10, 50, 100}
 
 	for _, count := range packageCounts {
@@ -449,37 +432,16 @@ func TestS3Cache_ExistingPackagesBatchOptimization(t *testing.T) {
 				rateLimiter:         rate.NewLimiter(rate.Limit(defaultRateLimit), defaultBurstLimit),
 			}
 
-			// Measure time for batch check (using ListObjects)
+			// Measure time for parallel HeadObject checks
 			start := time.Now()
 			existing, err := s3Cache.ExistingPackages(context.Background(), packages)
-			batchDuration := time.Since(start)
+			duration := time.Since(start)
 			require.NoError(t, err)
 			require.Equal(t, count, len(existing), "All packages should be found")
 
-			// Measure time for sequential check (fallback method)
-			start = time.Now()
-			existingSeq, err := s3Cache.existingPackagesSequential(context.Background(), packages)
-			seqDuration := time.Since(start)
-			require.NoError(t, err)
-			require.Equal(t, count, len(existingSeq), "All packages should be found")
-
-			// Calculate speedup
-			speedup := float64(seqDuration) / float64(batchDuration)
-
 			t.Logf("Package count: %d", count)
-			t.Logf("Batch (ListObjects): %v", batchDuration)
-			t.Logf("Sequential (HeadObject): %v", seqDuration)
-			t.Logf("Speedup: %.2fx", speedup)
-
-			// For larger package counts, batch should be significantly faster
-			// Note: Using 2.5x threshold to account for CI environment variability
-			if count >= 50 {
-				require.Greater(t, speedup, 2.5, "Batch optimization should be at least 2.5x faster for 50+ packages")
-			} else {
-				// For small package counts, batch overhead may reduce speedup
-				// Use a lower threshold to avoid flaky tests
-				require.Greater(t, speedup, 0.45, "Batch optimization should not be significantly slower than sequential")
-			}
+			t.Logf("Duration: %v", duration)
+			t.Logf("Packages/sec: %.2f", float64(count)/duration.Seconds())
 		})
 	}
 }
@@ -527,39 +489,6 @@ func BenchmarkS3Cache_ExistingPackages(b *testing.B) {
 			}
 		})
 
-		b.Run(fmt.Sprintf("%d-packages-sequential", count), func(b *testing.B) {
-			// Create packages
-			packages := make([]cache.Package, count)
-			for i := 0; i < count; i++ {
-				packages[i] = &mockPackagePerf{
-					version:  fmt.Sprintf("package%d:v%d", i, i),
-					fullName: fmt.Sprintf("package%d", i),
-				}
-			}
-
-			// Setup mock storage
-			mockStorage := createRealisticMockS3StorageMultiple(b, count)
-
-			config := &cache.RemoteConfig{
-				BucketName: "test-bucket",
-			}
-
-			s3Cache := &S3Cache{
-				storage:             mockStorage,
-				cfg:                 config,
-				workerCount:         defaultWorkerCount,
-				downloadWorkerCount: defaultDownloadWorkerCount,
-				rateLimiter:         rate.NewLimiter(rate.Limit(defaultRateLimit), defaultBurstLimit),
-			}
-
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				_, err := s3Cache.existingPackagesSequential(context.Background(), packages)
-				if err != nil {
-					b.Fatal(err)
-				}
-			}
-		})
 	}
 }
 

--- a/pkg/leeway/cache/remote/s3_provenance_test.go
+++ b/pkg/leeway/cache/remote/s3_provenance_test.go
@@ -361,10 +361,4 @@ func (m *mockS3StorageForProvenance) UploadObject(ctx context.Context, key strin
 	return nil
 }
 
-func (m *mockS3StorageForProvenance) ListObjects(ctx context.Context, prefix string) ([]string, error) {
-	var keys []string
-	for key := range m.objects {
-		keys = append(keys, key)
-	}
-	return keys, nil
-}
+

--- a/pkg/leeway/cache/remote/s3_provenance_test.go
+++ b/pkg/leeway/cache/remote/s3_provenance_test.go
@@ -360,5 +360,3 @@ func (m *mockS3StorageForProvenance) UploadObject(ctx context.Context, key strin
 	m.objects[key] = data
 	return nil
 }
-
-

--- a/pkg/leeway/cache/remote/s3_resilience_test.go
+++ b/pkg/leeway/cache/remote/s3_resilience_test.go
@@ -153,8 +153,6 @@ func (m *mockS3WithFailures) UploadObject(ctx context.Context, key string, src s
 	return nil
 }
 
-
-
 // Mock package for testing
 type mockPackageResilience struct {
 	version  string

--- a/pkg/leeway/cache/remote/s3_resilience_test.go
+++ b/pkg/leeway/cache/remote/s3_resilience_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -154,19 +153,7 @@ func (m *mockS3WithFailures) UploadObject(ctx context.Context, key string, src s
 	return nil
 }
 
-func (m *mockS3WithFailures) ListObjects(ctx context.Context, prefix string) ([]string, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 
-	var keys []string
-	for key := range m.data {
-		if strings.HasPrefix(key, prefix) {
-			keys = append(keys, key)
-		}
-	}
-
-	return keys, nil
-}
 
 // Mock package for testing
 type mockPackageResilience struct {

--- a/pkg/leeway/cache/remote/s3_slsa_test.go
+++ b/pkg/leeway/cache/remote/s3_slsa_test.go
@@ -71,8 +71,6 @@ func (m *mockS3StorageWithSLSA) getCallLog() []string {
 	return result
 }
 
-
-
 type mockNotFoundError struct {
 	key string
 }

--- a/pkg/leeway/cache/remote/s3_slsa_test.go
+++ b/pkg/leeway/cache/remote/s3_slsa_test.go
@@ -71,15 +71,7 @@ func (m *mockS3StorageWithSLSA) getCallLog() []string {
 	return result
 }
 
-func (m *mockS3StorageWithSLSA) ListObjects(ctx context.Context, prefix string) ([]string, error) {
-	var keys []string
-	for key := range m.objects {
-		if strings.HasPrefix(key, prefix) {
-			keys = append(keys, key)
-		}
-	}
-	return keys, nil
-}
+
 
 type mockNotFoundError struct {
 	key string

--- a/pkg/leeway/cache/remote/s3_test.go
+++ b/pkg/leeway/cache/remote/s3_test.go
@@ -23,10 +23,9 @@ import (
 
 // mockS3Client implements a mock S3 client for testing
 type mockS3Client struct {
-	headObjectFunc    func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
-	getObjectFunc     func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
-	putObjectFunc     func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
-	listObjectsV2Func func(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	headObjectFunc func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	getObjectFunc  func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	putObjectFunc  func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 }
 
 func (m *mockS3Client) HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
@@ -66,12 +65,7 @@ func (m *mockS3Client) UploadPart(ctx context.Context, params *s3.UploadPartInpu
 	return &s3.UploadPartOutput{}, nil
 }
 
-func (m *mockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
-	if m.listObjectsV2Func != nil {
-		return m.listObjectsV2Func(ctx, params, optFns...)
-	}
-	return &s3.ListObjectsV2Output{}, nil
-}
+
 
 func TestS3Cache_ExistingPackages(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -81,7 +75,6 @@ func TestS3Cache_ExistingPackages(t *testing.T) {
 		name            string
 		packages        []cache.Package
 		mockHeadObject  func(key string) (*s3.HeadObjectOutput, error)
-		mockListObjects func(prefix string) (*s3.ListObjectsV2Output, error)
 		expectedResults map[string]struct{}
 		expectError     bool
 	}{
@@ -95,14 +88,6 @@ func TestS3Cache_ExistingPackages(t *testing.T) {
 					return &s3.HeadObjectOutput{}, nil
 				}
 				return nil, &types.NoSuchKey{}
-			},
-			mockListObjects: func(prefix string) (*s3.ListObjectsV2Output, error) {
-				key := "v1.tar.gz"
-				return &s3.ListObjectsV2Output{
-					Contents: []types.Object{
-						{Key: &key},
-					},
-				}, nil
 			},
 			expectedResults: map[string]struct{}{
 				"v1": {},
@@ -122,14 +107,6 @@ func TestS3Cache_ExistingPackages(t *testing.T) {
 				}
 				return nil, &types.NoSuchKey{}
 			},
-			mockListObjects: func(prefix string) (*s3.ListObjectsV2Output, error) {
-				key := "v1.tar"
-				return &s3.ListObjectsV2Output{
-					Contents: []types.Object{
-						{Key: &key},
-					},
-				}, nil
-			},
 			expectedResults: map[string]struct{}{
 				"v1": {},
 			},
@@ -142,11 +119,6 @@ func TestS3Cache_ExistingPackages(t *testing.T) {
 			mockHeadObject: func(key string) (*s3.HeadObjectOutput, error) {
 				return nil, &types.NoSuchKey{}
 			},
-			mockListObjects: func(prefix string) (*s3.ListObjectsV2Output, error) {
-				return &s3.ListObjectsV2Output{
-					Contents: []types.Object{},
-				}, nil
-			},
 			expectedResults: map[string]struct{}{},
 		},
 		{
@@ -156,14 +128,6 @@ func TestS3Cache_ExistingPackages(t *testing.T) {
 			},
 			mockHeadObject: func(key string) (*s3.HeadObjectOutput, error) {
 				return &s3.HeadObjectOutput{}, nil
-			},
-			mockListObjects: func(prefix string) (*s3.ListObjectsV2Output, error) {
-				key := "v1.tar.gz"
-				return &s3.ListObjectsV2Output{
-					Contents: []types.Object{
-						{Key: &key},
-					},
-				}, nil
 			},
 			expectedResults: map[string]struct{}{},
 			expectError:     false,
@@ -175,12 +139,6 @@ func TestS3Cache_ExistingPackages(t *testing.T) {
 			mockClient := &mockS3Client{
 				headObjectFunc: func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
 					return tt.mockHeadObject(*params.Key)
-				},
-				listObjectsV2Func: func(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
-					if tt.mockListObjects != nil {
-						return tt.mockListObjects(*params.Prefix)
-					}
-					return &s3.ListObjectsV2Output{}, nil
 				},
 			}
 

--- a/pkg/leeway/cache/remote/s3_test.go
+++ b/pkg/leeway/cache/remote/s3_test.go
@@ -65,8 +65,6 @@ func (m *mockS3Client) UploadPart(ctx context.Context, params *s3.UploadPartInpu
 	return &s3.UploadPartOutput{}, nil
 }
 
-
-
 func TestS3Cache_ExistingPackages(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/leeway/cache/types.go
+++ b/pkg/leeway/cache/types.go
@@ -89,6 +89,24 @@ const (
 	DownloadStatusSkipped
 )
 
+// String returns a string representation of the download status
+func (s DownloadStatus) String() string {
+	switch s {
+	case DownloadStatusSuccess:
+		return "success"
+	case DownloadStatusNotFound:
+		return "not_found"
+	case DownloadStatusFailed:
+		return "failed"
+	case DownloadStatusVerificationFailed:
+		return "verification_failed"
+	case DownloadStatusSkipped:
+		return "skipped"
+	default:
+		return "unknown"
+	}
+}
+
 // DownloadResult contains the outcome of a single package download attempt.
 // This enables callers to make informed decisions about retry strategies
 // and avoid unnecessary rebuilds when transient failures occur.
@@ -97,6 +115,8 @@ type DownloadResult struct {
 	Status DownloadStatus
 	// Err contains the error if Status is Failed or VerificationFailed
 	Err error
+	// Bytes is the size of the downloaded artifact in bytes (0 if not downloaded)
+	Bytes int64
 }
 
 // RemoteCache can download and upload build artifacts into a local cache
@@ -133,9 +153,6 @@ type ObjectStorage interface {
 
 	// UploadObject uploads a local file to remote storage
 	UploadObject(ctx context.Context, key string, src string) error
-
-	// ListObjects lists objects with the given prefix
-	ListObjects(ctx context.Context, prefix string) ([]string, error)
 }
 
 // Config holds configuration for cache implementations

--- a/pkg/leeway/reporter.go
+++ b/pkg/leeway/reporter.go
@@ -731,7 +731,7 @@ type OTelReporter struct {
 	rootSpan     trace.Span
 	packageCtxs  map[string]context.Context
 	packageSpans map[string]trace.Span
-	phaseSpans   map[string]trace.Span   // key: "packageName:phaseName"
+	phaseSpans   map[string]trace.Span      // key: "packageName:phaseName"
 	phaseCtxs    map[string]context.Context // key: "packageName:phaseName"
 	mu           sync.RWMutex
 }

--- a/pkg/leeway/telemetry/tracer.go
+++ b/pkg/leeway/telemetry/tracer.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -15,8 +17,16 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// leewayVersion is set by the build system and used for telemetry
-var leewayVersion = "unknown"
+var (
+	// leewayVersion is set by the build system and used for telemetry
+	leewayVersion = "unknown"
+
+	// tracerProvider holds the global tracer provider
+	tracerProvider *sdktrace.TracerProvider
+
+	// initialized tracks whether tracing has been initialized
+	initialized bool
+)
 
 // SetLeewayVersion sets the leeway version for telemetry reporting
 func SetLeewayVersion(version string) {
@@ -25,13 +35,16 @@ func SetLeewayVersion(version string) {
 	}
 }
 
-// InitTracer initializes the OpenTelemetry tracer with OTLP HTTP exporter.
-// The endpoint parameter specifies the OTLP endpoint URL (e.g., "localhost:4318").
-// The insecure parameter controls whether to use TLS (false = use TLS, true = no TLS).
-// Returns the TracerProvider which must be shut down when done.
-func InitTracer(ctx context.Context, endpoint string, insecure bool) (*sdktrace.TracerProvider, error) {
+// Initialize sets up the OpenTelemetry tracer with OTLP HTTP exporter.
+// This should be called once at application startup.
+// Returns an error if initialization fails, or nil if tracing is disabled (empty endpoint).
+func Initialize(ctx context.Context, endpoint string, insecure bool) error {
 	if endpoint == "" {
-		return nil, xerrors.Errorf("OTLP endpoint not provided")
+		return nil
+	}
+
+	if initialized {
+		return nil
 	}
 
 	// Create OTLP HTTP exporter with optional TLS
@@ -44,28 +57,28 @@ func InitTracer(ctx context.Context, endpoint string, insecure bool) (*sdktrace.
 
 	exporter, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create OTLP exporter: %w", err)
+		return xerrors.Errorf("failed to create OTLP exporter: %w", err)
 	}
 
 	// Create resource with service information
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("leeway"),
-			semconv.ServiceVersionKey.String(getLeewayVersion()),
+			semconv.ServiceVersionKey.String(leewayVersion),
 		),
 	)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create resource: %w", err)
+		return xerrors.Errorf("failed to create resource: %w", err)
 	}
 
 	// Create tracer provider
-	tp := sdktrace.NewTracerProvider(
+	tracerProvider = sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
 	)
 
 	// Set global tracer provider
-	otel.SetTracerProvider(tp)
+	otel.SetTracerProvider(tracerProvider)
 
 	// Set global propagator for W3C Trace Context
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
@@ -73,36 +86,62 @@ func InitTracer(ctx context.Context, endpoint string, insecure bool) (*sdktrace.
 		propagation.Baggage{},
 	))
 
-	return tp, nil
+	initialized = true
+	return nil
 }
 
 // Shutdown flushes any pending spans and shuts down the tracer provider.
-// It uses a timeout context to ensure shutdown completes within a reasonable time.
-func Shutdown(ctx context.Context, tp *sdktrace.TracerProvider) error {
-	if tp == nil {
+func Shutdown(ctx context.Context) error {
+	if tracerProvider == nil {
 		return nil
 	}
 
-	// Create a timeout context for shutdown
 	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	if err := tp.Shutdown(shutdownCtx); err != nil {
-		return xerrors.Errorf("failed to shutdown tracer provider: %w", err)
-	}
+	err := tracerProvider.Shutdown(shutdownCtx)
+	tracerProvider = nil
+	initialized = false
+	return err
+}
 
-	return nil
+// Enabled returns true if tracing has been initialized.
+func Enabled() bool {
+	return initialized
+}
+
+// Tracer returns the global tracer for leeway.
+func Tracer() trace.Tracer {
+	return otel.GetTracerProvider().Tracer("github.com/gitpod-io/leeway")
+}
+
+// StartSpan creates a new span with the given name and attributes.
+func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return Tracer().Start(ctx, name, trace.WithAttributes(attrs...))
+}
+
+// FinishSpan ends a span and sets its status based on the error.
+// Usage: defer telemetry.FinishSpan(span, &err)
+func FinishSpan(span trace.Span, err *error) {
+	if span == nil {
+		return
+	}
+	if err != nil && *err != nil {
+		span.RecordError(*err)
+		span.SetStatus(codes.Error, (*err).Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.End()
 }
 
 // ParseTraceContext parses W3C Trace Context headers (traceparent and tracestate)
 // and returns a context with the extracted trace information.
-// Format: traceparent = "00-{trace-id}-{span-id}-{flags}"
 func ParseTraceContext(traceparent, tracestate string) (context.Context, error) {
 	if traceparent == "" {
 		return context.Background(), nil
 	}
 
-	// Create a carrier with the trace context headers
 	carrier := propagation.MapCarrier{
 		"traceparent": traceparent,
 	}
@@ -110,7 +149,6 @@ func ParseTraceContext(traceparent, tracestate string) (context.Context, error) 
 		carrier["tracestate"] = tracestate
 	}
 
-	// Extract the trace context using W3C Trace Context propagator
 	ctx := context.Background()
 	propagator := propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
@@ -118,7 +156,6 @@ func ParseTraceContext(traceparent, tracestate string) (context.Context, error) 
 	)
 	ctx = propagator.Extract(ctx, carrier)
 
-	// Verify that we extracted a valid span context
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if !spanCtx.IsValid() {
 		return nil, xerrors.Errorf("invalid trace context: traceparent=%s", traceparent)
@@ -127,20 +164,12 @@ func ParseTraceContext(traceparent, tracestate string) (context.Context, error) 
 	return ctx, nil
 }
 
-// getLeewayVersion returns the leeway version set via SetLeewayVersion.
-// Returns "unknown" if version was not set.
-func getLeewayVersion() string {
-	return leewayVersion
-}
-
 // FormatTraceContext formats a span context into W3C Trace Context format.
-// This is useful for propagating trace context to child processes.
 func FormatTraceContext(spanCtx trace.SpanContext) (traceparent, tracestate string) {
 	if !spanCtx.IsValid() {
 		return "", ""
 	}
 
-	// Use the propagator to format the trace context properly
 	carrier := propagation.MapCarrier{}
 	propagator := propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
@@ -149,10 +178,7 @@ func FormatTraceContext(spanCtx trace.SpanContext) (traceparent, tracestate stri
 	ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
 	propagator.Inject(ctx, carrier)
 
-	traceparent = carrier.Get("traceparent")
-	tracestate = carrier.Get("tracestate")
-
-	return traceparent, tracestate
+	return carrier.Get("traceparent"), carrier.Get("tracestate")
 }
 
 // ValidateTraceParent validates the format of a traceparent header.
@@ -166,22 +192,18 @@ func ValidateTraceParent(traceparent string) error {
 		return xerrors.Errorf("invalid traceparent format: expected 4 parts, got %d", len(parts))
 	}
 
-	// Validate version
 	if parts[0] != "00" {
 		return xerrors.Errorf("unsupported traceparent version: %s", parts[0])
 	}
 
-	// Validate trace ID length (32 hex chars)
 	if len(parts[1]) != 32 {
 		return xerrors.Errorf("invalid trace ID length: expected 32, got %d", len(parts[1]))
 	}
 
-	// Validate span ID length (16 hex chars)
 	if len(parts[2]) != 16 {
 		return xerrors.Errorf("invalid span ID length: expected 16, got %d", len(parts[2]))
 	}
 
-	// Validate flags length (2 hex chars)
 	if len(parts[3]) != 2 {
 		return xerrors.Errorf("invalid flags length: expected 2, got %d", len(parts[3]))
 	}

--- a/pkg/leeway/telemetry/tracer_test.go
+++ b/pkg/leeway/telemetry/tracer_test.go
@@ -166,17 +166,21 @@ func TestFormatTraceContext_Invalid(t *testing.T) {
 	}
 }
 
-func TestInitTracer_NoEndpoint(t *testing.T) {
-	_, err := InitTracer(context.Background(), "", false)
-	if err == nil {
-		t.Error("InitTracer() should fail when endpoint is empty")
+func TestInitialize_NoEndpoint(t *testing.T) {
+	// Empty endpoint should not error - it just disables tracing
+	err := Initialize(context.Background(), "", false)
+	if err != nil {
+		t.Errorf("Initialize() with empty endpoint should not error, got %v", err)
+	}
+	if Enabled() {
+		t.Error("Enabled() should return false when endpoint is empty")
 	}
 }
 
-func TestShutdown_NilProvider(t *testing.T) {
-	// Should not panic with nil provider
-	err := Shutdown(context.Background(), nil)
+func TestShutdown_NotInitialized(t *testing.T) {
+	// Should not panic when not initialized
+	err := Shutdown(context.Background())
 	if err != nil {
-		t.Errorf("Shutdown() with nil provider should not return error, got %v", err)
+		t.Errorf("Shutdown() when not initialized should not return error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Description

Adds a `leeway.command` trace span that wraps the entire build command execution, capturing time spent on workspace loading and cache operations that weren't previously traced.

Also fixes a timeout issue where `ExistingPackages` would fail after 60 seconds on S3 buckets with millions of objects. The previous implementation used `ListObjects` with an empty prefix to enumerate all objects. Now uses parallel `HeadObject` calls to check only the specific keys needed.

## Related Issue(s)

Fixes CORE-6616
Part of CORE-6596

## How to test

<img width="1658" height="245" alt="image" src="https://github.com/user-attachments/assets/45b378af-2714-470e-b013-92c0a50e41d3" />


1. Run a build with tracing enabled:
   ```
   leeway build --otel-endpoint localhost:4318 --otel-insecure :pkg
   ```
2. Verify `leeway.command` span wraps `leeway.build` span
3. For S3 cache fix: run against a bucket with many objects and verify no timeout on `ExistingPackages`