### PR TITLE
feat: add --go-library-weak-deps CLI flag

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -241,6 +241,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("report-github", os.Getenv("GITHUB_OUTPUT") != "", "Report package build success/failure to GitHub Actions using the GITHUB_OUTPUT environment variable")
 	cmd.Flags().Bool("fixed-build-dir", true, "Use a fixed build directory for each package, instead of based on the package version, to better utilize caches based on absolute paths (defaults to true)")
 	cmd.Flags().Bool("docker-export-to-cache", false, "Export Docker images to cache instead of pushing directly (enables SLSA L3 compliance)")
+	cmd.Flags().Bool("go-library-weak-deps", false, "Treat Go library dependencies as weak dependencies (copy source instead of built artifacts)")
 }
 
 func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
@@ -412,6 +413,11 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		dockerExportSet = true
 	}
 
+	goLibraryWeakDeps, err := cmd.Flags().GetBool("go-library-weak-deps")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return []leeway.BuildOption{
 		leeway.WithLocalCache(localCache),
 		leeway.WithRemoteCache(remoteCache),
@@ -430,6 +436,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		leeway.WithInFlightChecksums(inFlightChecksums),
 		leeway.WithDockerExportToCache(dockerExportToCache, dockerExportSet),
 		leeway.WithDockerExportEnv(dockerExportEnvValue, dockerExportEnvSet),
+		leeway.WithGoLibraryWeakDeps(goLibraryWeakDeps),
 	}, localCache
 }
 

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -492,6 +492,11 @@ type buildOptions struct {
 	DockerExportEnvValue bool // Value from explicit user env var
 	DockerExportEnvSet   bool // Whether user explicitly set env var (before workspace)
 
+	// GoLibraryWeakDeps enables treating Go library dependencies as weak dependencies.
+	// When enabled, Go library deps copy source code instead of built artifacts,
+	// allowing parallel builds while still running tests.
+	GoLibraryWeakDeps bool
+
 	context *buildContext
 }
 
@@ -636,6 +641,16 @@ func WithDockerExportEnv(value, isSet bool) BuildOption {
 	return func(opts *buildOptions) error {
 		opts.DockerExportEnvValue = value
 		opts.DockerExportEnvSet = isSet
+		return nil
+	}
+}
+
+// WithGoLibraryWeakDeps enables treating Go library dependencies as weak dependencies.
+// When enabled, Go library deps copy source code instead of built artifacts,
+// allowing parallel builds while still running tests.
+func WithGoLibraryWeakDeps(enabled bool) BuildOption {
+	return func(opts *buildOptions) error {
+		opts.GoLibraryWeakDeps = enabled
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

Add opt-in CLI flag `--go-library-weak-deps` for treating Go library dependencies as weak dependencies.

## Motivation

This provides the infrastructure for the weak deps feature (PR #325), allowing it to be enabled via opt-in flag for safer rollout.

## Changes

- Add `--go-library-weak-deps` flag to build command
- Add `WithGoLibraryWeakDeps` build option
- Add `GoLibraryWeakDeps` field to `buildOptions` struct

## Usage

```bash
leeway build --go-library-weak-deps :mypackage
```

When enabled, Go library deps will:
- Copy source code instead of built artifacts
- Build in parallel (don't block dependent packages)
- Still run tests for the library
- Propagate failures to dependent packages

## Note

This PR only adds the flag infrastructure. The actual implementation will be in PR #325, which will check this flag before enabling weak dependency behavior.