### PR TITLE
Add --disable-sbom flag and LEEWAY_DISABLE_SBOM env var

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -241,6 +241,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("report-github", os.Getenv("GITHUB_OUTPUT") != "", "Report package build success/failure to GitHub Actions using the GITHUB_OUTPUT environment variable")
 	cmd.Flags().Bool("fixed-build-dir", true, "Use a fixed build directory for each package, instead of based on the package version, to better utilize caches based on absolute paths (defaults to true)")
 	cmd.Flags().Bool("docker-export-to-cache", false, "Export Docker images to cache instead of pushing directly (enables SLSA L3 compliance)")
+	cmd.Flags().Bool("disable-sbom", false, "Disable SBOM generation during build (overrides workspace config)")
 }
 
 func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
@@ -412,6 +413,17 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		dockerExportSet = true
 	}
 
+	// Get disable-sbom setting (env var as default, CLI flag overrides)
+	disableSBOMDefault := os.Getenv(EnvvarDisableSBOM) == "true"
+	disableSBOM, err := cmd.Flags().GetBool("disable-sbom")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// If flag wasn't explicitly set, use environment variable
+	if !cmd.Flags().Changed("disable-sbom") {
+		disableSBOM = disableSBOMDefault
+	}
+
 	return []leeway.BuildOption{
 		leeway.WithLocalCache(localCache),
 		leeway.WithRemoteCache(remoteCache),
@@ -430,6 +442,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, cache.LocalCache) {
 		leeway.WithInFlightChecksums(inFlightChecksums),
 		leeway.WithDockerExportToCache(dockerExportToCache, dockerExportSet),
 		leeway.WithDockerExportEnv(dockerExportEnvValue, dockerExportEnvSet),
+		leeway.WithDisableSBOM(disableSBOM),
 	}, localCache
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,9 @@ const (
 
 	// EnvvarMaxSigningConcurrency configures maximum concurrent signing operations
 	EnvvarMaxSigningConcurrency = "LEEWAY_MAX_SIGNING_CONCURRENCY"
+
+	// EnvvarDisableSBOM disables SBOM generation during builds
+	EnvvarDisableSBOM = "LEEWAY_DISABLE_SBOM"
 )
 
 const (
@@ -134,6 +137,7 @@ variables have an effect on leeway:
         <light_blue>LEEWAY_SLSA_SOURCE_URI</>  Expected source URI for SLSA verification (github.com/owner/repo).
 <light_blue>LEEWAY_SLSA_REQUIRE_ATTESTATION</>  Require valid attestations; missing/invalid → build locally (true/false).
 <light_blue>LEEWAY_ENABLE_IN_FLIGHT_CHECKSUMS</>  Enable checksumming of cache artifacts (true/false).
+            <light_blue>LEEWAY_DISABLE_SBOM</>  Disable SBOM generation during builds (true/false).
            <light_blue>LEEWAY_EXPERIMENTAL</>  Enables experimental leeway features and commands.
 `),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -492,6 +492,8 @@ type buildOptions struct {
 	DockerExportEnvValue bool // Value from explicit user env var
 	DockerExportEnvSet   bool // Whether user explicitly set env var (before workspace)
 
+	DisableSBOM bool // Disable SBOM generation (overrides workspace config)
+
 	context *buildContext
 }
 
@@ -636,6 +638,14 @@ func WithDockerExportEnv(value, isSet bool) BuildOption {
 	return func(opts *buildOptions) error {
 		opts.DockerExportEnvValue = value
 		opts.DockerExportEnvSet = isSet
+		return nil
+	}
+}
+
+// WithDisableSBOM disables SBOM generation during build (overrides workspace config)
+func WithDisableSBOM(disable bool) BuildOption {
+	return func(opts *buildOptions) error {
+		opts.DisableSBOM = disable
 		return nil
 	}
 }
@@ -897,7 +907,8 @@ func Build(pkg *Package, opts ...BuildOption) (err error) {
 	// This ensures we scan even cached packages that weren't rebuilt
 	// Only scan packages that were successfully built or downloaded to avoid
 	// errors when a dependency build failed in a parallel goroutine
-	if pkg.C.W.SBOM.Enabled && pkg.C.W.SBOM.ScanVulnerabilities {
+	// DisableSBOM build option overrides workspace config.
+	if pkg.C.W.SBOM.Enabled && pkg.C.W.SBOM.ScanVulnerabilities && !ctx.DisableSBOM {
 		if err := scanAllPackagesForVulnerabilities(ctx, allpkg, pkgstatus); err != nil {
 			return err
 		}
@@ -1261,7 +1272,8 @@ func (p *Package) build(buildctx *buildContext) (err error) {
 
 	// Generate SBOM if enabled (after packaging - written alongside artifact)
 	// SBOM files are stored outside the tar.gz to maintain artifact determinism.
-	if p.C.W.SBOM.Enabled {
+	// DisableSBOM build option overrides workspace config.
+	if p.C.W.SBOM.Enabled && !buildctx.DisableSBOM {
 		if par, ok := buildctx.Reporter.(PhaseAwareReporter); ok {
 			par.PackageBuildPhaseStarted(p, PackageBuildPhaseSBOM)
 		}


### PR DESCRIPTION
## Description

Add option to disable SBOM generation during individual builds, providing fine-grained control beyond the workspace-level `sbom.enabled` setting.

## Related Issue(s)

N/A

## How to test

```bash
# Via CLI flag
leeway build --disable-sbom :mypackage

# Via environment variable
LEEWAY_DISABLE_SBOM=true leeway build :mypackage

# CLI flag overrides env var
LEEWAY_DISABLE_SBOM=true leeway build --disable-sbom=false :mypackage  # SBOM enabled
```