### PR TITLE
fix: drop test.paused/test.continued spans from test tracing

### DIFF
--- a/pkg/leeway/gotest_trace.go
+++ b/pkg/leeway/gotest_trace.go
@@ -133,10 +133,9 @@ func (t *GoTestTracer) handleEvent(event *goTestEvent) {
 	switch event.Action {
 	case "run":
 		t.handleRun(event)
-	case "pause":
-		t.handlePause(event)
-	case "cont":
-		t.handleCont(event)
+	case "pause", "cont":
+		// Intentionally dropped: these events generate high-volume spans
+		// (test.paused/test.continued) with no diagnostic value.
 	case "pass", "fail", "skip":
 		t.handleEnd(event)
 	case "output":
@@ -203,36 +202,6 @@ func (t *GoTestTracer) handlePackageStart(event *goTestEvent) {
 	)
 
 	t.spans[key] = &testSpanData{span: span}
-}
-
-// handlePause records that a test was paused (for t.Parallel())
-func (t *GoTestTracer) handlePause(event *goTestEvent) {
-	if event.Test == "" {
-		return
-	}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	key := spanKey(event.Package, event.Test)
-	if data, ok := t.spans[key]; ok {
-		data.span.AddEvent("test.paused", trace.WithTimestamp(event.Time))
-	}
-}
-
-// handleCont records that a paused test continued
-func (t *GoTestTracer) handleCont(event *goTestEvent) {
-	if event.Test == "" {
-		return
-	}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	key := spanKey(event.Package, event.Test)
-	if data, ok := t.spans[key]; ok {
-		data.span.AddEvent("test.continued", trace.WithTimestamp(event.Time))
-	}
 }
 
 // handleEnd ends a span for a completed test

--- a/pkg/leeway/gotest_trace_test.go
+++ b/pkg/leeway/gotest_trace_test.go
@@ -154,14 +154,13 @@ func TestGoTestTracer_ParallelTests(t *testing.T) {
 		t.Fatal("TestParallel span not found")
 	}
 
-	// Verify pause and cont events were recorded
-	eventNames := make([]string, 0)
-	for _, e := range testSpan.Events {
-		eventNames = append(eventNames, e.Name)
-	}
-
-	if len(eventNames) != 2 {
-		t.Errorf("expected 2 events (pause, cont), got %d: %v", len(eventNames), eventNames)
+	// Verify pause and cont events are NOT recorded (dropped to reduce span volume)
+	if len(testSpan.Events) != 0 {
+		eventNames := make([]string, 0, len(testSpan.Events))
+		for _, e := range testSpan.Events {
+			eventNames = append(eventNames, e.Name)
+		}
+		t.Errorf("expected 0 events (pause/cont dropped), got %d: %v", len(testSpan.Events), eventNames)
 	}
 }
 


### PR DESCRIPTION
The `test.paused` and `test.continued` span events account for ~4.34M events/week (54% of the ci/leeway dataset in Honeycomb). These are Go test lifecycle bookkeeping events emitted when `t.Parallel()` pauses and resumes tests — they carry no diagnostic value since actual test results are captured in individual `test: *` spans.

This PR removes the `handlePause` and `handleCont` methods and their dispatch in `handleEvent`, so these events are no longer emitted.