### PR TITLE
fix(sbom): reuse grype database provider

### DIFF
--- a/pkg/leeway/sbom-scan.go
+++ b/pkg/leeway/sbom-scan.go
@@ -45,6 +45,26 @@ type PackageVulnerabilityStats struct {
 	Ignored    int    `json:"ignored"`
 }
 
+type sbomVulnerabilityScanner interface {
+	Scan(buildctx *buildContext, p *Package, sbomFile string, outputDir string) (*PackageVulnerabilityStats, error)
+	Close() error
+}
+
+type grypeVulnerabilityScanner struct {
+	provider vulnerability.Provider
+	status   *vulnerability.ProviderStatus
+}
+
+func (s *grypeVulnerabilityScanner) Scan(buildctx *buildContext, p *Package, sbomFile string, outputDir string) (*PackageVulnerabilityStats, error) {
+	return scanSBOMForVulnerabilities(buildctx, p, sbomFile, outputDir, s.provider, s.status)
+}
+
+func (s *grypeVulnerabilityScanner) Close() error {
+	return s.provider.Close()
+}
+
+type vulnerabilityScannerFactory func(buildctx *buildContext, p *Package) (sbomVulnerabilityScanner, error)
+
 // scanAllPackagesForVulnerabilities scans all packages for vulnerabilities.
 // This function is called after the build process completes to identify security issues
 // in all built packages, including those loaded from cache. It generates comprehensive
@@ -54,6 +74,10 @@ type PackageVulnerabilityStats struct {
 // This prevents errors when a dependency build fails in a parallel goroutine but the main
 // build continues (due to the build lock mechanism allowing other goroutines to proceed).
 func scanAllPackagesForVulnerabilities(buildctx *buildContext, packages []*Package, pkgstatus map[*Package]PackageBuildStatus, customOutputDir ...string) error {
+	return scanAllPackagesForVulnerabilitiesWithScannerFactory(buildctx, packages, pkgstatus, newGrypeVulnerabilityScanner, customOutputDir...)
+}
+
+func scanAllPackagesForVulnerabilitiesWithScannerFactory(buildctx *buildContext, packages []*Package, pkgstatus map[*Package]PackageBuildStatus, scannerFactory vulnerabilityScannerFactory, customOutputDir ...string) error {
 	if len(packages) == 0 {
 		return nil
 	}
@@ -75,6 +99,17 @@ func scanAllPackagesForVulnerabilities(buildctx *buildContext, packages []*Packa
 		buildctx.Reporter.PackageBuildLog(nil, true, []byte(errMsg+"\n"))
 		return xerrors.Errorf(errMsg)
 	}
+
+	var scanner sbomVulnerabilityScanner
+	var scannerPackage *Package
+	defer func() {
+		if scanner == nil {
+			return
+		}
+		if closeErr := scanner.Close(); closeErr != nil {
+			buildctx.Reporter.PackageBuildLog(scannerPackage, true, []byte("failed to close vulnerability provider: "+closeErr.Error()+"\n"))
+		}
+	}()
 
 	// Process each package
 	for _, p := range packages {
@@ -153,7 +188,19 @@ func scanAllPackagesForVulnerabilities(buildctx *buildContext, packages []*Packa
 		}
 
 		// Scan for vulnerabilities
-		stats, err := scanSBOMForVulnerabilities(buildctx, p, sbomFilename, outputDir)
+		if scanner == nil {
+			// Scanner construction opens and may update Grype's database. Keep that
+			// lifecycle outside the package scan so update failures are retried once.
+			scanner, err = scannerFactory(buildctx, p)
+			if err != nil {
+				errMsg := fmt.Sprintf("failed to initialize vulnerability scanner: %s", err)
+				buildctx.Reporter.PackageBuildLog(p, true, []byte(errMsg+"\n"))
+				return xerrors.Errorf(errMsg)
+			}
+			scannerPackage = p
+		}
+
+		stats, err := scanner.Scan(buildctx, p, sbomFilename, outputDir)
 		if err != nil {
 			buildctx.Reporter.PackageBuildLog(p, false, fmt.Appendf(nil, "Failed to scan package %s for vulnerabilities: %s\n", p.FullName(), err.Error()))
 			failedPackages = append(failedPackages, p.FullName())
@@ -242,12 +289,8 @@ func ScanAllPackagesForVulnerabilities(localCache cache.LocalCache, packages []*
 	return scanAllPackagesForVulnerabilities(buildctx, packages, pkgstatus, customOutputDir...)
 }
 
-// scanSBOMForVulnerabilities scans an SBOM file for vulnerabilities and generates reports.
-// This function can be called independently of the build process to analyze a specific SBOM file.
-// It returns vulnerability statistics for the package and an error if the scan fails.
-// The function handles loading the vulnerability database, parsing the SBOM, finding matches,
-// and generating reports in multiple formats.
-func scanSBOMForVulnerabilities(buildctx *buildContext, p *Package, sbomFile string, outputDir string) (stats *PackageVulnerabilityStats, err error) {
+// scanSBOMForVulnerabilities scans an SBOM file using an initialized vulnerability provider.
+func scanSBOMForVulnerabilities(buildctx *buildContext, p *Package, sbomFile string, outputDir string, vulnProvider vulnerability.Provider, vulnProviderStatus *vulnerability.ProviderStatus) (stats *PackageVulnerabilityStats, err error) {
 	if !p.C.W.SBOM.Enabled {
 		return nil, xerrors.Errorf("SBOM feature is disabled, cannot scan for vulnerabilities")
 	}
@@ -259,19 +302,6 @@ func scanSBOMForVulnerabilities(buildctx *buildContext, p *Package, sbomFile str
 		buildctx.Reporter.PackageBuildLog(p, true, []byte(errMsg+"\n"))
 		return nil, xerrors.Errorf(errMsg)
 	}
-
-	// Load vulnerability database
-	vulnProvider, vulnProviderStatus, err := loadVulnerabilityDB(buildctx, p)
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to load vulnerability database: %s", err)
-		buildctx.Reporter.PackageBuildLog(p, true, []byte(errMsg+"\n"))
-		return nil, xerrors.Errorf(errMsg)
-	}
-	defer func() {
-		if closeErr := vulnProvider.Close(); closeErr != nil {
-			buildctx.Reporter.PackageBuildLog(p, true, []byte("failed to close vulnerability provider: "+closeErr.Error()+"\n"))
-		}
-	}()
 
 	buildctx.Reporter.PackageBuildLog(p, false, fmt.Appendf(nil, "Using vulnerability database (path: %s, built on: %s)\n",
 		vulnProviderStatus.Path, vulnProviderStatus.Built.Format("2006-01-02")))
@@ -673,9 +703,62 @@ func WritePackageVulnerabilityMarkdown(outputDir string, stats []*PackageVulnera
 	return nil
 }
 
+const (
+	vulnerabilityDBLoadMaxAttempts    = 3
+	vulnerabilityDBLoadInitialBackoff = time.Second
+)
+
+type vulnerabilityDBLoadFunc func() (vulnerability.Provider, *vulnerability.ProviderStatus, error)
+
+type vulnerabilityDBLoader struct {
+	load           vulnerabilityDBLoadFunc
+	sleep          func(time.Duration)
+	maxAttempts    int
+	initialBackoff time.Duration
+}
+
+func newGrypeVulnerabilityScanner(buildctx *buildContext, p *Package) (sbomVulnerabilityScanner, error) {
+	loader := vulnerabilityDBLoader{
+		load:           loadVulnerabilityDB,
+		sleep:          time.Sleep,
+		maxAttempts:    vulnerabilityDBLoadMaxAttempts,
+		initialBackoff: vulnerabilityDBLoadInitialBackoff,
+	}
+
+	provider, status, err := loader.Load(buildctx, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return &grypeVulnerabilityScanner{provider: provider, status: status}, nil
+}
+
+func (l vulnerabilityDBLoader) Load(buildctx *buildContext, p *Package) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+	backoff := l.initialBackoff
+	var lastErr error
+
+	for attempt := 1; attempt <= l.maxAttempts; attempt++ {
+		buildctx.Reporter.PackageBuildLog(p, false, fmt.Appendf(nil, "Loading vulnerability database (attempt %d/%d) ...\n", attempt, l.maxAttempts))
+
+		provider, status, err := l.load()
+		if err == nil {
+			return provider, status, nil
+		}
+		lastErr = err
+
+		if attempt < l.maxAttempts {
+			buildctx.Reporter.PackageBuildLog(p, true, fmt.Appendf(nil, "Failed to load vulnerability database: %s; retrying in %s\n", err, backoff))
+			l.sleep(backoff)
+			backoff *= 2
+		}
+	}
+
+	return nil, nil, xerrors.Errorf("failed to load vulnerability database after %d attempts: %w", l.maxAttempts, lastErr)
+}
+
 // loadVulnerabilityDB initializes and loads the vulnerability database.
 // It configures the database provider and handles downloading/updating the database if needed.
-func loadVulnerabilityDB(buildctx *buildContext, p *Package) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+func loadVulnerabilityDB() (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 	distConfig := distribution.DefaultConfig()
 
 	id := clio.Identification{
@@ -684,8 +767,6 @@ func loadVulnerabilityDB(buildctx *buildContext, p *Package) (vulnerability.Prov
 	}
 
 	installConfig := installation.DefaultConfig(id)
-
-	buildctx.Reporter.PackageBuildLog(p, false, []byte("Loading vulnerability database (this may take a moment on first run) ...\n"))
 
 	provider, status, err := grype.LoadVulnerabilityDB(distConfig, installConfig, true)
 	if err != nil {

--- a/pkg/leeway/sbom_scan_test.go
+++ b/pkg/leeway/sbom_scan_test.go
@@ -1,0 +1,247 @@
+package leeway
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/google/go-cmp/cmp"
+
+	leewaycache "github.com/gitpod-io/leeway/pkg/leeway/cache"
+)
+
+func TestVulnerabilityDBLoaderLoad(t *testing.T) {
+	t.Parallel()
+
+	type Expectation struct {
+		Calls  int
+		Sleeps []time.Duration
+		Err    string
+	}
+
+	tests := []struct {
+		Name       string
+		LoadErrors []string
+		Expected   Expectation
+	}{
+		{
+			Name:       "loads_on_first_attempt",
+			LoadErrors: []string{""},
+			Expected: Expectation{
+				Calls: 1,
+			},
+		},
+		{
+			Name:       "retries_with_bounded_backoff",
+			LoadErrors: []string{"temporary failure", "temporary failure", ""},
+			Expected: Expectation{
+				Calls:  3,
+				Sleeps: []time.Duration{time.Second, 2 * time.Second},
+			},
+		},
+		{
+			Name:       "returns_last_error_after_max_attempts",
+			LoadErrors: []string{"first failure", "second failure", "final failure"},
+			Expected: Expectation{
+				Calls:  3,
+				Sleeps: []time.Duration{time.Second, 2 * time.Second},
+				Err:    "failed to load vulnerability database after 3 attempts: final failure",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			var got Expectation
+			loader := vulnerabilityDBLoader{
+				maxAttempts:    3,
+				initialBackoff: time.Second,
+				sleep: func(delay time.Duration) {
+					got.Sleeps = append(got.Sleeps, delay)
+				},
+				load: func() (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+					loadErr := tc.LoadErrors[got.Calls]
+					got.Calls++
+					if loadErr != "" {
+						return nil, nil, errors.New(loadErr)
+					}
+					return nil, &vulnerability.ProviderStatus{}, nil
+				},
+			}
+
+			buildctx := &buildContext{buildOptions: buildOptions{Reporter: &NoopReporter{}}}
+			_, _, err := loader.Load(buildctx, NewTestPackage("scan"))
+			if err != nil {
+				got.Err = err.Error()
+			}
+
+			if diff := cmp.Diff(tc.Expected, got); diff != "" {
+				t.Errorf("vulnerabilityDBLoader.Load() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestScanAllPackagesForVulnerabilitiesReusesScanner(t *testing.T) {
+	t.Parallel()
+
+	type Expectation struct {
+		FactoryCalls     int
+		ScannedPackages  []string
+		CloseCalls       int
+		CloseErrorLogged bool
+		Err              string
+	}
+
+	tests := []struct {
+		Name           string
+		PackageStatus  PackageBuildStatus
+		FactoryErr     string
+		ScanErrPackage string
+		CloseErr       string
+		Expected       Expectation
+	}{
+		{
+			Name: "reuses_and_closes_one_scanner",
+			Expected: Expectation{
+				FactoryCalls:    1,
+				ScannedPackages: []string{"testcomp:first", "testcomp:second"},
+				CloseCalls:      1,
+			},
+		},
+		{
+			Name:          "skips_scanner_without_scannable_packages",
+			PackageStatus: PackageNotBuiltYet,
+			Expected:      Expectation{},
+		},
+		{
+			Name:       "stops_when_scanner_initialization_fails",
+			FactoryErr: "database unavailable",
+			Expected: Expectation{
+				FactoryCalls: 1,
+				Err:          "failed to initialize vulnerability scanner: database unavailable",
+			},
+		},
+		{
+			Name:           "keeps_scanning_after_package_failure",
+			ScanErrPackage: "testcomp:first",
+			Expected: Expectation{
+				FactoryCalls:    1,
+				ScannedPackages: []string{"testcomp:first", "testcomp:second"},
+				CloseCalls:      1,
+				Err:             "vulnerability scan failed for packages: testcomp:first",
+			},
+		},
+		{
+			Name:     "logs_scanner_close_failure",
+			CloseErr: "close failure",
+			Expected: Expectation{
+				FactoryCalls:     1,
+				ScannedPackages:  []string{"testcomp:first", "testcomp:second"},
+				CloseCalls:       1,
+				CloseErrorLogged: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			var got Expectation
+			reporter := &sbomScanRecordingReporter{}
+			buildctx := &buildContext{buildOptions: buildOptions{
+				Reporter:   reporter,
+				LocalCache: sbomScanTestCache{},
+			}}
+
+			packages := []*Package{NewTestPackage("first"), NewTestPackage("second")}
+			pkgstatus := make(map[*Package]PackageBuildStatus, len(packages))
+			packageStatus := tc.PackageStatus
+			if packageStatus == "" {
+				packageStatus = PackageBuilt
+			}
+			for _, pkg := range packages {
+				pkg.C.W.SBOM.Enabled = true
+				artifactPath := filepath.Join(t.TempDir(), pkg.FilesystemSafeName()+".tar.gz")
+				if err := os.WriteFile(artifactPath+".sbom.cdx.json", []byte("{}"), 0644); err != nil {
+					got.Err = "test setup: " + err.Error()
+					break
+				}
+				buildctx.LocalCache.(sbomScanTestCache)[pkg.FullName()] = artifactPath
+				pkgstatus[pkg] = packageStatus
+			}
+
+			scanner := &fakeSBOMVulnerabilityScanner{
+				scanErrPackage: tc.ScanErrPackage,
+				closeErr:       tc.CloseErr,
+			}
+			factory := func(_ *buildContext, _ *Package) (sbomVulnerabilityScanner, error) {
+				got.FactoryCalls++
+				if tc.FactoryErr != "" {
+					return nil, errors.New(tc.FactoryErr)
+				}
+				return scanner, nil
+			}
+
+			if got.Err == "" {
+				err := scanAllPackagesForVulnerabilitiesWithScannerFactory(buildctx, packages, pkgstatus, factory, t.TempDir())
+				if err != nil {
+					got.Err = err.Error()
+				}
+			}
+			got.ScannedPackages = scanner.scannedPackages
+			got.CloseCalls = scanner.closeCalls
+			got.CloseErrorLogged = strings.Contains(strings.Join(reporter.logs, ""), tc.CloseErr) && tc.CloseErr != ""
+
+			if diff := cmp.Diff(tc.Expected, got); diff != "" {
+				t.Errorf("scanAllPackagesForVulnerabilitiesWithScannerFactory() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type fakeSBOMVulnerabilityScanner struct {
+	scannedPackages []string
+	scanErrPackage  string
+	closeErr        string
+	closeCalls      int
+}
+
+func (s *fakeSBOMVulnerabilityScanner) Scan(_ *buildContext, p *Package, _ string, _ string) (*PackageVulnerabilityStats, error) {
+	s.scannedPackages = append(s.scannedPackages, p.FullName())
+	if p.FullName() == s.scanErrPackage {
+		return nil, errors.New("scan failure")
+	}
+	return &PackageVulnerabilityStats{Name: p.FullName()}, nil
+}
+
+func (s *fakeSBOMVulnerabilityScanner) Close() error {
+	s.closeCalls++
+	if s.closeErr != "" {
+		return errors.New(s.closeErr)
+	}
+	return nil
+}
+
+type sbomScanTestCache map[string]string
+
+func (c sbomScanTestCache) Location(pkg leewaycache.Package) (string, bool) {
+	path, ok := c[pkg.FullName()]
+	return path, ok
+}
+
+type sbomScanRecordingReporter struct {
+	NoopReporter
+	logs []string
+}
+
+func (r *sbomScanRecordingReporter) PackageBuildLog(_ *Package, _ bool, buf []byte) {
+	r.logs = append(r.logs, string(buf))
+}


### PR DESCRIPTION
## Summary

- initialize the embedded Grype vulnerability database once per scan operation
- retry database initialization up to three times with bounded backoff
- reuse and close one provider across all package SBOM scans
- preserve lazy initialization when no package is eligible for scanning

## Motivation

Leeway currently loads and auto-updates Grype's database inside each package scan. When the initial database download fails, every package repeats the same download attempt, turning one transient failure into a long build failure.

Preloading the database with a separate `grype` executable avoids that loop but couples Leeway to an independently versioned CLI and database schema. This change keeps database ownership inside Leeway's embedded Grype library.

Related investigation: https://github.com/gitpod-io/gitpod-next/pull/27991

## Compatibility

- No exported API or workspace configuration changes.
- Individual SBOM parsing and matching failures continue to be collected across packages.
- Database initialization failures now stop after three attempts instead of being retried once per package.
- No external Grype CLI preload is required after consumers adopt a Leeway release containing this change.

## Verification

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `golangci-lint run ./... --new-from-rev HEAD`
- `git diff --check`

The repository-wide local golangci-lint v2 run also reports pre-existing findings outside this diff; changed-line lint reports zero issues.

## Documentation

No docs changes needed. This changes internal vulnerability-database lifecycle and failure handling without changing commands or configuration.